### PR TITLE
Change default text weight to 1.2499999rem

### DIFF
--- a/packages/foundations-vars/src/vars.pcss
+++ b/packages/foundations-vars/src/vars.pcss
@@ -16,7 +16,7 @@
   /* font-size: 1.2499999rem uses thinner text decoration on links rather than 1.25rem */
 
   /* Typography */
-  --type-body-l: 1.25rem; /* 20px */
+  --type-body-l: 1.2499999rem; /* 20px */
   --type-body-s: 1.125rem; /* 18px */
 
   --type-line-height: 1.5; /* 32px */


### PR DESCRIPTION
font-size: 1.2499999rem uses thinner text decoration on links rather than 1.25rem