### PR TITLE
Remove inline list padding

### DIFF
--- a/packages/component-card--product/dist/card--product.css
+++ b/packages/component-card--product/dist/card--product.css
@@ -286,7 +286,6 @@
   text-decoration: underline;
 }
 .coop-c-card--product .coop-c-card__link:hover .coop-c-card__image {
-  -webkit-transform: none;
   transform: none;
 }
 .coop-c-card--product .coop-c-card__link .coop-c-card__title {
@@ -303,9 +302,7 @@
   overflow: hidden;
   float: none;
   width: 100%;
-  transition: -webkit-transform 0.2s ease-in;
   transition: transform 0.2s ease-in;
-  transition: transform 0.2s ease-in, -webkit-transform 0.2s ease-in;
   text-align: center;
 }
 .coop-c-card--product .coop-c-card__link .coop-c-card__image picture {

--- a/packages/component-signpost/dist/signpost.css
+++ b/packages/component-signpost/dist/signpost.css
@@ -270,16 +270,13 @@
   display: block;
   flex-basis: 0.75rem;
   max-width: 0.75rem;
-  transition: -webkit-transform 0.2s ease-in-out;
   transition: transform 0.2s ease-in-out;
-  transition: transform 0.2s ease-in-out, -webkit-transform 0.2s ease-in-out;
   width: 0.75rem;
   height: 1.375rem;
   overflow: hidden;
 }
 .coop-c-signpost a:focus .coop-c-signpost__icon,
 .coop-c-signpost a:hover .coop-c-signpost__icon {
-  -webkit-transform: translateX(0.25rem);
   transform: translateX(0.25rem);
 }
 .coop-c-signpost__icon__svg {

--- a/packages/component-squircles/dist/squircles.css
+++ b/packages/component-squircles/dist/squircles.css
@@ -7,7 +7,6 @@
   height: 114px;
   width: 118px;
   z-index: 10;
-  -webkit-transform: scale(0.66);
   transform: scale(0.66);
 }
 .coop-c-squircle__media {
@@ -88,7 +87,6 @@
   padding: 0.875rem 0 0;
   top: -38px;
   right: -32px;
-  -webkit-transform: scale(0.7);
   transform: scale(0.7);
 }
 .coop-c-squircle--super_saver_squircle {

--- a/packages/css-foundations/dist/foundations.css
+++ b/packages/css-foundations/dist/foundations.css
@@ -870,7 +870,8 @@ ol {
 }
   }
 
-.coop-u-list-bare {
+.coop-u-list-bare,
+.coop-u-list-inline {
   list-style-type: none;
   padding: 0;
 }
@@ -986,7 +987,6 @@ a:active,
   a:focus,
   .coop-t-link:active,
   .coop-t-link:focus {
-    -webkit-transition: none;
     transition: none;
     outline: 2px solid #eb5f1e;
     outline: 2px solid var(--color-link--focus);
@@ -1007,7 +1007,6 @@ a:active,
 
 .coop-t-link-white:active,
   .coop-t-link-white:focus {
-    -webkit-transition: none;
     transition: none;
     outline: 2px dotted #ffffff;
     outline: 2px dotted var(--color-white);
@@ -1028,7 +1027,6 @@ a:active,
 
 .coop-t-link-black:active,
   .coop-t-link-black:focus {
-    -webkit-transition: none;
     transition: none;
     outline: 2px dotted #000000;
     outline: 2px dotted var(--color-black);
@@ -1159,13 +1157,9 @@ a.coop-t-nounderline,
 }
 
 .coop-l-grid {
-  display: -webkit-box;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
   flex-direction: column;
   flex-wrap: nowrap;
-  -webkit-box-pack: justify;
   justify-content: space-between;
   margin-top: -2rem;
   margin-left: -1rem;
@@ -1173,7 +1167,6 @@ a.coop-t-nounderline,
 }
 
 .coop-l-grid-item {
-  -webkit-box-flex: 1;
   flex: 1 0 auto;
   max-width: 100%;
   padding-left: 1rem;
@@ -1182,14 +1175,11 @@ a.coop-t-nounderline,
 }
 
 .coop-l-grid--fluid .coop-l-grid-item {
-  -webkit-box-flex: 1;
   flex: 1;
 }
 
 @media (min-width: 480px) {
   .coop-l-grid {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
     flex-direction: row;
     flex-wrap: wrap;
   }
@@ -1213,7 +1203,6 @@ a.coop-t-nounderline,
 }
 
 .coop-u-flex {
-  display: -webkit-box;
   display: flex;
 }
 
@@ -1226,48 +1215,35 @@ a.coop-t-nounderline,
 }
 
 .coop-u-flex-row {
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
   flex-direction: row;
 }
 
 .coop-u-flex-column {
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
   flex-direction: column;
 }
 
 .coop-u-flex-row-reverse {
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: reverse;
   flex-direction: row-reverse;
 }
 
 .coop-u-flex-column-reverse {
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: reverse;
   flex-direction: column-reverse;
 }
 
 .coop-u-flex-start {
-  -webkit-box-pack: start;
   justify-content: flex-start;
 }
 
 .coop-u-flex-center {
-  -webkit-box-pack: center;
   justify-content: center;
 }
 
 .coop-u-flex-end {
-  -webkit-box-pack: end;
   justify-content: flex-end;
 }
 
 .coop-u-flex-centered {
-  -webkit-box-pack: center;
   justify-content: center;
-  -webkit-box-align: center;
   align-items: center;
 }
 
@@ -1658,7 +1634,6 @@ a.coop-t-nounderline,
   text-align: center;
   border: 0;
   border-radius: 7px;
-  -webkit-transition: all 0.15s linear;
   transition: all 0.15s linear;
   outline: none;
   text-decoration: none;
@@ -1684,7 +1659,6 @@ a.coop-t-nounderline,
 }
 
 .coop-btn:focus {
-  -webkit-transition: none;
   transition: none;
   outline: 2px solid #eb5f1e;
   outline: 2px solid var(--color-link--focus);
@@ -1866,7 +1840,6 @@ textarea,
   color: #282828;
   color: var(--color-text);
   outline: 0;
-  -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   font-size: 1.25rem
 }
@@ -1879,7 +1852,6 @@ input:focus, .coop-form__input:focus, textarea:focus, .coop-form__textarea:focus
     outline-offset: 3px;
     outline: 2px dotted #eb5f1e;
     outline: 2px dotted var(--color-link--focus);
-    -webkit-transition: none;
     transition: none;
   }
 
@@ -1889,7 +1861,6 @@ input:hover::-webkit-input-placeholder, .coop-form__input:hover::-webkit-input-p
   }
 
 input:focus::-webkit-input-placeholder, .coop-form__input:focus::-webkit-input-placeholder, textarea:focus::-webkit-input-placeholder, .coop-form__textarea:focus::-webkit-input-placeholder {
-    -webkit-transition: opacity 0.5s 0.5s ease;
     transition: opacity 0.5s 0.5s ease;
     opacity: 0;
   }
@@ -1923,7 +1894,6 @@ select,
   color: #282828;
   color: var(--color-text);
   outline: 0;
-  -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   font-size: 1.25rem
 }
@@ -1936,7 +1906,6 @@ select:focus, .coop-form__select:focus {
     outline-offset: 3px;
     outline: 2px dotted #eb5f1e;
     outline: 2px dotted var(--color-link--focus);
-    -webkit-transition: none;
     transition: none;
   }
 
@@ -1946,7 +1915,6 @@ select:hover::-webkit-input-placeholder, .coop-form__select:hover::-webkit-input
   }
 
 select:focus::-webkit-input-placeholder, .coop-form__select:focus::-webkit-input-placeholder {
-    -webkit-transition: opacity 0.5s 0.5s ease;
     transition: opacity 0.5s 0.5s ease;
     opacity: 0;
   }
@@ -2064,7 +2032,6 @@ input[type="radio"],
   border-color: #000000;
   outline-offset: 3px;
   outline: 2px dotted #eec300;
-  -webkit-transition: none;
   transition: none;
 }
 
@@ -2105,8 +2072,7 @@ input[type="radio"],
   background: none;
   border: solid;
   border-width: 0 0 3px 3px;
-  -webkit-transform: rotate(-45deg);
-          transform: rotate(-45deg);
+  transform: rotate(-45deg);
   border-top-color: transparent;
   width: 15px;
   height: 8px;
@@ -4198,24 +4164,16 @@ table ul,
 }
 
 .coop-l-flexed {
-  display: -webkit-box;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
   flex-direction: column;
-  -webkit-box-align: center;
   align-items: center;
 }
 
 @media (min-width: 60em) {
   .coop-l-flexed {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
     flex-direction: row;
   }
   .coop-l-flexed--reversed {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: reverse;
     flex-direction: row-reverse;
   }
 }

--- a/packages/foundations-buttons/dist/buttons.css
+++ b/packages/foundations-buttons/dist/buttons.css
@@ -162,7 +162,6 @@
   text-align: center;
   border: 0;
   border-radius: 7px;
-  -webkit-transition: all 0.15s linear;
   transition: all 0.15s linear;
   outline: none;
   text-decoration: none;
@@ -187,7 +186,6 @@
 }
 
 .coop-btn:focus {
-  -webkit-transition: none;
   transition: none;
   outline: 2px solid #eb5f1e;
   outline: 2px solid var(--color-link--focus);

--- a/packages/foundations-forms/dist/forms.css
+++ b/packages/foundations-forms/dist/forms.css
@@ -241,7 +241,6 @@ textarea,
   color: #282828;
   color: var(--color-text);
   outline: 0;
-  -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   font-size: 1.25rem;
 }
@@ -257,7 +256,6 @@ textarea:focus,
   outline-offset: 3px;
   outline: 2px dotted #eb5f1e;
   outline: 2px dotted var(--color-link--focus);
-  -webkit-transition: none;
   transition: none;
 }
 
@@ -273,7 +271,6 @@ input:focus::-webkit-input-placeholder,
 .coop-form__input:focus::-webkit-input-placeholder,
 textarea:focus::-webkit-input-placeholder,
 .coop-form__textarea:focus::-webkit-input-placeholder {
-  -webkit-transition: opacity 0.5s 0.5s ease;
   transition: opacity 0.5s 0.5s ease;
   opacity: 0;
 }
@@ -310,7 +307,6 @@ select,
   color: #282828;
   color: var(--color-text);
   outline: 0;
-  -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   font-size: 1.25rem;
 }
@@ -324,7 +320,6 @@ select:focus,
   outline-offset: 3px;
   outline: 2px dotted #eb5f1e;
   outline: 2px dotted var(--color-link--focus);
-  -webkit-transition: none;
   transition: none;
 }
 
@@ -336,7 +331,6 @@ select:hover::-webkit-input-placeholder,
 
 select:focus::-webkit-input-placeholder,
 .coop-form__select:focus::-webkit-input-placeholder {
-  -webkit-transition: opacity 0.5s 0.5s ease;
   transition: opacity 0.5s 0.5s ease;
   opacity: 0;
 }
@@ -454,7 +448,6 @@ input[type="radio"],
   border-color: #000000;
   outline-offset: 3px;
   outline: 2px dotted #eec300;
-  -webkit-transition: none;
   transition: none;
 }
 
@@ -495,7 +488,6 @@ input[type="radio"],
   background: none;
   border: solid;
   border-width: 0 0 3px 3px;
-  -webkit-transform: rotate(-45deg);
   transform: rotate(-45deg);
   border-top-color: transparent;
   width: 15px;

--- a/packages/foundations-grid/dist/grid.css
+++ b/packages/foundations-grid/dist/grid.css
@@ -6,20 +6,15 @@
   padding-right: 1rem;
 }
 .coop-l-grid {
-  display: -webkit-box;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
   flex-direction: column;
   flex-wrap: nowrap;
-  -webkit-box-pack: justify;
   justify-content: space-between;
   margin-top: -2rem;
   margin-left: -1rem;
   margin-right: -1rem;
 }
 .coop-l-grid-item {
-  -webkit-box-flex: 1;
   flex: 1 0 auto;
   max-width: 100%;
   padding-left: 1rem;
@@ -27,13 +22,10 @@
   padding-top: 2rem;
 }
 .coop-l-grid--fluid .coop-l-grid-item {
-  -webkit-box-flex: 1;
   flex: 1;
 }
 @media (min-width: 480px) {
   .coop-l-grid {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
     flex-direction: row;
     flex-wrap: wrap;
   }
@@ -55,7 +47,6 @@
   }
 }
 .coop-u-flex {
-  display: -webkit-box;
   display: flex;
 }
 .coop-u-flex-wrap {
@@ -65,40 +56,27 @@
   flex-wrap: nowrap;
 }
 .coop-u-flex-row {
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
   flex-direction: row;
 }
 .coop-u-flex-column {
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
   flex-direction: column;
 }
 .coop-u-flex-row-reverse {
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: reverse;
   flex-direction: row-reverse;
 }
 .coop-u-flex-column-reverse {
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: reverse;
   flex-direction: column-reverse;
 }
 .coop-u-flex-start {
-  -webkit-box-pack: start;
   justify-content: flex-start;
 }
 .coop-u-flex-center {
-  -webkit-box-pack: center;
   justify-content: center;
 }
 .coop-u-flex-end {
-  -webkit-box-pack: end;
   justify-content: flex-end;
 }
 .coop-u-flex-centered {
-  -webkit-box-pack: center;
   justify-content: center;
-  -webkit-box-align: center;
   align-items: center;
 }

--- a/packages/foundations-grid/dist/legacy-grid.css
+++ b/packages/foundations-grid/dist/legacy-grid.css
@@ -1068,23 +1068,15 @@
   }
 }
 .coop-l-flexed {
-  display: -webkit-box;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
   flex-direction: column;
-  -webkit-box-align: center;
   align-items: center;
 }
 @media (min-width: 60em) {
   .coop-l-flexed {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
     flex-direction: row;
   }
   .coop-l-flexed--reversed {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: reverse;
     flex-direction: row-reverse;
   }
 }

--- a/packages/foundations-typography/dist/typography.css
+++ b/packages/foundations-typography/dist/typography.css
@@ -427,7 +427,8 @@ ol {
     margin-bottom: var(--spacing-16);
   }
 }
-.coop-u-list-bare {
+.coop-u-list-bare,
+.coop-u-list-inline {
   list-style-type: none;
   padding: 0;
 }
@@ -528,7 +529,6 @@ a:active,
 a:focus,
 .coop-t-link:active,
 .coop-t-link:focus {
-  -webkit-transition: none;
   transition: none;
   outline: 2px solid #eb5f1e;
   outline: 2px solid var(--color-link--focus);
@@ -546,7 +546,6 @@ a:focus,
 }
 .coop-t-link-white:active,
 .coop-t-link-white:focus {
-  -webkit-transition: none;
   transition: none;
   outline: 2px dotted #ffffff;
   outline: 2px dotted var(--color-white);
@@ -564,7 +563,6 @@ a:focus,
 }
 .coop-t-link-black:active,
 .coop-t-link-black:focus {
-  -webkit-transition: none;
   transition: none;
   outline: 2px dotted #000000;
   outline: 2px dotted var(--color-black);

--- a/packages/foundations-typography/src/typography.pcss
+++ b/packages/foundations-typography/src/typography.pcss
@@ -153,7 +153,8 @@ ol {
   }
 }
 
-.coop-u-list-bare {
+.coop-u-list-bare,
+.coop-u-list-inline {
   list-style-type: none;
   padding: 0;
 }

--- a/packages/shared-component--featureCard/dist/featureCard.css
+++ b/packages/shared-component--featureCard/dist/featureCard.css
@@ -48,7 +48,7 @@
   --color-black: #000;
   --color-link: #00729a;
   --color-link--hover: #000102;
-  --color-link--focus: #eec300;
+  --color-link--focus: #eb5f1e;
   --color-link--active: #005981;
   --color-link--visited: #004c67;
   --color-button-primary: #0f8482;
@@ -88,6 +88,12 @@
   --color-orange-mid: #f8642c;
   --color-red-mid: #d63118;
   --color-red-dark: #9f2a00;
+  --color-blue-notification: #326bb7;
+  --color-blue-notification-light: #d4eaf5;
+  --color-orange-alert: #ff9d34;
+  --color-orange-alert-light: #ffebe3;
+  --color-red-error: #d63118;
+  --color-red-error-light: #fef3f4;
 }
 .coop-c-featureCard {
   display: flex;

--- a/packages/shared-component--hero/dist/hero.css
+++ b/packages/shared-component--hero/dist/hero.css
@@ -48,7 +48,7 @@
   --color-black: #000;
   --color-link: #00729a;
   --color-link--hover: #000102;
-  --color-link--focus: #eec300;
+  --color-link--focus: #eb5f1e;
   --color-link--active: #005981;
   --color-link--visited: #004c67;
   --color-button-primary: #0f8482;
@@ -88,6 +88,12 @@
   --color-orange-mid: #f8642c;
   --color-red-mid: #d63118;
   --color-red-dark: #9f2a00;
+  --color-blue-notification: #326bb7;
+  --color-blue-notification-light: #d4eaf5;
+  --color-orange-alert: #ff9d34;
+  --color-orange-alert-light: #ffebe3;
+  --color-red-error: #d63118;
+  --color-red-error-light: #fef3f4;
 }
 .coop-c-hero {
   overflow: hidden;

--- a/packages/shared-component--image/dist/image.css
+++ b/packages/shared-component--image/dist/image.css
@@ -48,7 +48,7 @@
   --color-black: #000;
   --color-link: #00729a;
   --color-link--hover: #000102;
-  --color-link--focus: #eec300;
+  --color-link--focus: #eb5f1e;
   --color-link--active: #005981;
   --color-link--visited: #004c67;
   --color-button-primary: #0f8482;
@@ -88,6 +88,12 @@
   --color-orange-mid: #f8642c;
   --color-red-mid: #d63118;
   --color-red-dark: #9f2a00;
+  --color-blue-notification: #326bb7;
+  --color-blue-notification-light: #d4eaf5;
+  --color-orange-alert: #ff9d34;
+  --color-orange-alert-light: #ffebe3;
+  --color-red-error: #d63118;
+  --color-red-error-light: #fef3f4;
 }
 .coop-c-image {
   margin: 0 0 0.5rem;

--- a/packages/shared-component--linkList/dist/linkList.css
+++ b/packages/shared-component--linkList/dist/linkList.css
@@ -48,7 +48,7 @@
   --color-black: #000;
   --color-link: #00729a;
   --color-link--hover: #000102;
-  --color-link--focus: #eec300;
+  --color-link--focus: #eb5f1e;
   --color-link--active: #005981;
   --color-link--visited: #004c67;
   --color-button-primary: #0f8482;
@@ -88,6 +88,12 @@
   --color-orange-mid: #f8642c;
   --color-red-mid: #d63118;
   --color-red-dark: #9f2a00;
+  --color-blue-notification: #326bb7;
+  --color-blue-notification-light: #d4eaf5;
+  --color-orange-alert: #ff9d34;
+  --color-orange-alert-light: #ffebe3;
+  --color-red-error: #d63118;
+  --color-red-error-light: #fef3f4;
 }
 .coop-c-list-container__title {
   font-size: 28px;

--- a/packages/shared-component--membership/dist/membership.css
+++ b/packages/shared-component--membership/dist/membership.css
@@ -48,7 +48,7 @@
   --color-black: #000;
   --color-link: #00729a;
   --color-link--hover: #000102;
-  --color-link--focus: #eec300;
+  --color-link--focus: #eb5f1e;
   --color-link--active: #005981;
   --color-link--visited: #004c67;
   --color-button-primary: #0f8482;
@@ -88,6 +88,12 @@
   --color-orange-mid: #f8642c;
   --color-red-mid: #d63118;
   --color-red-dark: #9f2a00;
+  --color-blue-notification: #326bb7;
+  --color-blue-notification-light: #d4eaf5;
+  --color-orange-alert: #ff9d34;
+  --color-orange-alert-light: #ffebe3;
+  --color-red-error: #d63118;
+  --color-red-error-light: #fef3f4;
 }
 .coop-c-membershipmodule {
   padding: 1.5rem;

--- a/packages/shared-component--signpost/dist/signpost.css
+++ b/packages/shared-component--signpost/dist/signpost.css
@@ -48,7 +48,7 @@
   --color-black: #000;
   --color-link: #00729a;
   --color-link--hover: #000102;
-  --color-link--focus: #eec300;
+  --color-link--focus: #eb5f1e;
   --color-link--active: #005981;
   --color-link--visited: #004c67;
   --color-button-primary: #0f8482;
@@ -88,6 +88,12 @@
   --color-orange-mid: #f8642c;
   --color-red-mid: #d63118;
   --color-red-dark: #9f2a00;
+  --color-blue-notification: #326bb7;
+  --color-blue-notification-light: #d4eaf5;
+  --color-orange-alert: #ff9d34;
+  --color-orange-alert-light: #ffebe3;
+  --color-red-error: #d63118;
+  --color-red-error-light: #fef3f4;
 }
 .coop-c-signpost {
   flex-grow: 1;

--- a/packages/shared-component--statement/dist/statement.css
+++ b/packages/shared-component--statement/dist/statement.css
@@ -48,7 +48,7 @@
   --color-black: #000;
   --color-link: #00729a;
   --color-link--hover: #000102;
-  --color-link--focus: #eec300;
+  --color-link--focus: #eb5f1e;
   --color-link--active: #005981;
   --color-link--visited: #004c67;
   --color-button-primary: #0f8482;
@@ -88,6 +88,12 @@
   --color-orange-mid: #f8642c;
   --color-red-mid: #d63118;
   --color-red-dark: #9f2a00;
+  --color-blue-notification: #326bb7;
+  --color-blue-notification-light: #d4eaf5;
+  --color-orange-alert: #ff9d34;
+  --color-orange-alert-light: #ffebe3;
+  --color-red-error: #d63118;
+  --color-red-error-light: #fef3f4;
 }
 .coop-c-statement-block {
   overflow: hidden;

--- a/packages/shared-component--text/dist/text.css
+++ b/packages/shared-component--text/dist/text.css
@@ -48,7 +48,7 @@
   --color-black: #000;
   --color-link: #00729a;
   --color-link--hover: #000102;
-  --color-link--focus: #eec300;
+  --color-link--focus: #eb5f1e;
   --color-link--active: #005981;
   --color-link--visited: #004c67;
   --color-button-primary: #0f8482;
@@ -88,6 +88,12 @@
   --color-orange-mid: #f8642c;
   --color-red-mid: #d63118;
   --color-red-dark: #9f2a00;
+  --color-blue-notification: #326bb7;
+  --color-blue-notification-light: #d4eaf5;
+  --color-orange-alert: #ff9d34;
+  --color-orange-alert-light: #ffebe3;
+  --color-red-error: #d63118;
+  --color-red-error-light: #fef3f4;
 }
 .coop-c-text p {
   font-size: 1.125rem;

--- a/packages/shared-component--video/dist/video.css
+++ b/packages/shared-component--video/dist/video.css
@@ -48,7 +48,7 @@
   --color-black: #000;
   --color-link: #00729a;
   --color-link--hover: #000102;
-  --color-link--focus: #eec300;
+  --color-link--focus: #eb5f1e;
   --color-link--active: #005981;
   --color-link--visited: #004c67;
   --color-button-primary: #0f8482;
@@ -88,6 +88,12 @@
   --color-orange-mid: #f8642c;
   --color-red-mid: #d63118;
   --color-red-dark: #9f2a00;
+  --color-blue-notification: #326bb7;
+  --color-blue-notification-light: #d4eaf5;
+  --color-orange-alert: #ff9d34;
+  --color-orange-alert-light: #ffebe3;
+  --color-red-error: #d63118;
+  --color-red-error-light: #fef3f4;
 }
 .coop-c-video {
   padding-bottom: 56.25%;


### PR DESCRIPTION
Removes padding and list styles on lists with class `coop-u-list-inline`

Fixes #57 

A lot of the distribution files have been updated with the latest focus outline, so I assume this hadn't been build properly in the previous release. Also removed a lot of the webkit-specific rules, yet I haven't changed any of the `browserlist` config, assumption here is that those fixes are not required for our target browsers anymore. It might be worth trying to run a build on master and see if those assumptions are correct.