### PR TITLE
Use Ruby 2.6.3 from macOS Catalina

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: circleci/ruby:2.6.3-node
     steps:
       - checkout
       - run:

--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -8,8 +8,8 @@ LABEL maintainer="matt.tyas@coop.co.uk"
 RUN sudo curl -sSL https://rvm.io/mpapis.asc | gpg --import --no-tty
 RUN sudo curl -sSL https://get.rvm.io | bash -s stable
 
-RUN sudo rvm install ruby-2.5.1
-RUN sudo rvm --default use 2.5.1
+RUN sudo rvm install ruby-2.6.3
+RUN sudo rvm --default use 2.6.3
 
 
 # Install Bundler.

--- a/design-system/Gemfile
+++ b/design-system/Gemfile
@@ -1,5 +1,5 @@
 source 'http://rubygems.org'
-ruby '2.5.1'
+ruby '2.6.3'
 gem 'rack'
 gem 'puma'
 gem 'jekyll'

--- a/design-system/Gemfile.lock
+++ b/design-system/Gemfile.lock
@@ -109,7 +109,7 @@ DEPENDENCIES
   scss_lint
 
 RUBY VERSION
-   ruby 2.5.1
+   ruby 2.6.3
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Just tried jumping straight into the readme:
https://github.com/coopdigital/coop-frontend/blob/master/design-system/README.md

But there's a scary error!

```
$ bundle install

Warning: the running version of Bundler (1.17.2) is older than the version that created the lockfile (1.17.3). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Your Ruby version is 2.6.3, but your Gemfile specified 2.5.1
```

Can we upgrade the Ruby version to match what's bundled with macOS Catalina? 😊 

**macOS High Sierra 10.13** uses Ruby `2.3`
**macOS Mojave 10.14** uses Ruby `2.3`
**macOS Catalina 10.15** uses Ruby `2.6`

But the Co-op **design-system** uses Ruby `2.5.1` which leads to lots of wrangling with Brew or adjustments to Gemfiles.

This pull request lets it work out of the box with **macOS Catalina**.

