### PR TITLE
Fix missing blue button colour

### DIFF
--- a/packages/foundations-vars/src/vars.pcss
+++ b/packages/foundations-vars/src/vars.pcss
@@ -157,7 +157,7 @@
   --color-button-primary--hover: var(--color-button-green-primary-hover);
   --color-button-primary--active: var(--color-button-green-primary-active);
 
-  /* Primary blue */
+  /* Blue button */
   --color-button-blue: #00394e;
   --color-button-blue-hover: #4a6683;
   --color-button-blue-active: #2e4052;
@@ -176,9 +176,9 @@
   --color-button-white-active: var(--color-grey-mid-light);
 
   /* default button */
-  --color-button: var(--color-button-blue-primary);
-  --color-button--hover: var(--color-button-blue-primary-hover);
-  --color-button--active: var(--color-button-blue-primary-active);
+  --color-button: var(--color-button-blue);
+  --color-button--hover: var(--color-button-blue-hover);
+  --color-button--active: var(--color-button-blue-active);
 
   /* Notifications */
   --color-red-error: #d12430;


### PR DESCRIPTION
Left over from https://github.com/coopdigital/coop-frontend/pull/117 we're missing the CSS variable `--color-button-blue-primary`.

It should be `--color-button-blue` instead.

![Button colours](https://user-images.githubusercontent.com/415517/88208583-5b9e4780-cc49-11ea-9638-f878603c3827.png)
