### PR TITLE
Remove CSS custom properties from built files

### DIFF
--- a/packages/foundations-vars/package.json
+++ b/packages/foundations-vars/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "lint": "stylelint 'src/*.{css,pcss}' --config '../../.stylelintrc.js' --fix",
-    "build": "postcss src/*.pcss --dir dist/ --config '../../postcss.config.js' --ext css",
+    "build": "postcss src/*.pcss --dir dist/ --config './postcss.config.js' --ext css",
     "dist": "npm run lint && npm run build"
   },
   "repository": {

--- a/packages/foundations-vars/postcss.config.js
+++ b/packages/foundations-vars/postcss.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  map: {
+    inline: false
+  },
+  plugins: [
+    require('postcss-import'),
+    require('postcss-custom-media'),
+    require('postcss-custom-properties'),
+    require('postcss-nesting'),
+    require('postcss-calc'),
+    require('autoprefixer'),
+    require('cssnano'),
+  ],
+};

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,7 +5,9 @@ module.exports = {
   plugins: [
     require('postcss-import'),
     require('postcss-custom-media'),
-    require('postcss-custom-properties'),
+    require('postcss-custom-properties')({
+      preserve: false,
+    }),
     require('postcss-nesting'),
     require('postcss-calc'),
     require('autoprefixer'),


### PR DESCRIPTION
Following on from https://github.com/coopdigital/coop-frontend/pull/117 we now have a new colour palette 🎉 

But we have a problem with CSS custom properties:

```css
.example {
  background: #0f8482;
  background: var(--color-button-primary);
}
```

☝️ The above example _should_ use the new blue button colour.

### The problem
We bundle **vars.pcss** from `@coopdigital/foundations-vars` with almost every package.

What does this mean? Projects that import older versions of **vars.pcss** into their CSS builds will have the new colour palette overridden again (in most parts) back to the old one.

This PR turns the above example into:

```css
.example {
  background: #0f8482;
}
```

The custom properties will remain only in the source `*.pcss` files.