### PR TITLE
Allow @coopdigital/foundations-vars to be shared

### DIFF
--- a/packages/component-card--product/package.json
+++ b/packages/component-card--product/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/component-card--product/issues"
   },

--- a/packages/component-card/package.json
+++ b/packages/component-card/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/component-card/issues"
   },

--- a/packages/component-notification--alert/package-lock.json
+++ b/packages/component-notification--alert/package-lock.json
@@ -236,6 +236,12 @@
       "integrity": "sha512-az54Ru9Ezpe0Ax5Zs5747kZVqlDYr+PLCdDIMszyY60qd2IR3z75PkN1FAZWkGAa875qNTT5CviV2ZVU6GlMmw==",
       "dev": true
     },
+    "@coopdigital/foundations-vars": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@coopdigital/foundations-vars/-/foundations-vars-3.1.2.tgz",
+      "integrity": "sha512-TwT4E15FmBmemQZTmt3DNWIv6w28aemnSGwFdEFQ7Ex1tf4bvM8O65Vfu37Dd6oIA2E38yQqiLy3PGsbzTqDUw==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",

--- a/packages/component-notification--alert/package-lock.json
+++ b/packages/component-notification--alert/package-lock.json
@@ -233,8 +233,7 @@
     "@coopdigital/component-notification": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@coopdigital/component-notification/-/component-notification-1.0.8.tgz",
-      "integrity": "sha512-az54Ru9Ezpe0Ax5Zs5747kZVqlDYr+PLCdDIMszyY60qd2IR3z75PkN1FAZWkGAa875qNTT5CviV2ZVU6GlMmw==",
-      "dev": true
+      "integrity": "sha512-az54Ru9Ezpe0Ax5Zs5747kZVqlDYr+PLCdDIMszyY60qd2IR3z75PkN1FAZWkGAa875qNTT5CviV2ZVU6GlMmw=="
     },
     "@coopdigital/foundations-vars": {
       "version": "3.1.2",

--- a/packages/component-notification--alert/package.json
+++ b/packages/component-notification--alert/package.json
@@ -20,8 +20,10 @@
     "type": "git",
     "url": "git+https://github.com/coopdigital/coop-frontend/packages/notification--alert.git"
   },
+  "dependencies": {
+    "@coopdigital/component-notification": "^1.0.8"
+  },
   "devDependencies": {
-    "@coopdigital/component-notification": "^1.0.8",
     "@coopdigital/foundations-vars": "^3.1.2",
     "autoprefixer": "^9.8.5",
     "cssnano": "^4.1.10",
@@ -38,7 +40,6 @@
     "stylelint-prettier": "^1.1.2"
   },
   "peerDependencies": {
-    "@coopdigital/component-notification": ">= 1.0.8 < 2",
     "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
   },
   "bugs": {

--- a/packages/component-notification--alert/package.json
+++ b/packages/component-notification--alert/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@coopdigital/component-notification": "^1.0.8",
+    "@coopdigital/foundations-vars": "^3.1.2",
     "autoprefixer": "^9.8.5",
     "cssnano": "^4.1.10",
     "postcss": "^7.0.32",
@@ -35,6 +36,10 @@
     "stylelint": "^13.6.1",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
+  },
+  "peerDependencies": {
+    "@coopdigital/component-notification": ">= 1.0.8 < 2",
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
   },
   "bugs": {
     "url": "https://github.com/coopdigital/coop-frontend/packages/notification--alert/issues"

--- a/packages/component-notification/package-lock.json
+++ b/packages/component-notification/package-lock.json
@@ -230,6 +230,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@coopdigital/foundations-vars": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@coopdigital/foundations-vars/-/foundations-vars-3.1.2.tgz",
+      "integrity": "sha512-TwT4E15FmBmemQZTmt3DNWIv6w28aemnSGwFdEFQ7Ex1tf4bvM8O65Vfu37Dd6oIA2E38yQqiLy3PGsbzTqDUw==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",

--- a/packages/component-notification/package.json
+++ b/packages/component-notification/package.json
@@ -21,6 +21,7 @@
     "url": "git+https://github.com/coopdigital/coop-frontend/packages/component-notification.git"
   },
   "devDependencies": {
+    "@coopdigital/foundations-vars": "^3.1.2",
     "autoprefixer": "^9.8.5",
     "cssnano": "^4.1.10",
     "postcss": "^7.0.32",
@@ -34,6 +35,9 @@
     "stylelint": "^13.6.1",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
+  },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
   },
   "bugs": {
     "url": "https://github.com/coopdigital/coop-frontend/packages/component-notification/issues"

--- a/packages/component-notification/src/notification.pcss
+++ b/packages/component-notification/src/notification.pcss
@@ -1,3 +1,7 @@
+/* Card - notification */
+
+@import "@coopdigital/foundations-vars";
+
 .coop-c-notification {
   position: relative;
   padding: var(--spacing-16);

--- a/packages/component-search/package.json
+++ b/packages/component-search/package.json
@@ -36,5 +36,8 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "gitHead": "4f6dd72bd513475b22840730c22185415f50af8f"
 }

--- a/packages/component-signpost/package.json
+++ b/packages/component-signpost/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/component-signpost/issues"
   },

--- a/packages/component-skipnav/package.json
+++ b/packages/component-skipnav/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/component-skipnav/issues"
   },

--- a/packages/component-squircles/package.json
+++ b/packages/component-squircles/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/coop-frontend/issues"
   },

--- a/packages/component-tags/package.json
+++ b/packages/component-tags/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/component-tags/issues"
   },

--- a/packages/css-foundations/package-lock.json
+++ b/packages/css-foundations/package-lock.json
@@ -263,56 +263,47 @@
     "@coopdigital/foundations-buttons": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@coopdigital/foundations-buttons/-/foundations-buttons-2.1.3.tgz",
-      "integrity": "sha512-mRFWBb8ux+0c9aJ4UzU2g4nqyjUDjA8zuG2BaZSgpGx2oOkaXQIqMQZGmyQR87UY5pJhabQbU1y/5LsEfQ6vzg==",
-      "dev": true
+      "integrity": "sha512-mRFWBb8ux+0c9aJ4UzU2g4nqyjUDjA8zuG2BaZSgpGx2oOkaXQIqMQZGmyQR87UY5pJhabQbU1y/5LsEfQ6vzg=="
     },
     "@coopdigital/foundations-colors": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@coopdigital/foundations-colors/-/foundations-colors-2.1.3.tgz",
-      "integrity": "sha512-ag+pXM+1A/fG+KOXRfYd4AB+ZCsR7SzMV6EOHTWNcFliR0HHMlIansB9uKgzWEH36sytLIzp3ch25CNJJ0Sdjw==",
-      "dev": true
+      "integrity": "sha512-ag+pXM+1A/fG+KOXRfYd4AB+ZCsR7SzMV6EOHTWNcFliR0HHMlIansB9uKgzWEH36sytLIzp3ch25CNJJ0Sdjw=="
     },
     "@coopdigital/foundations-forms": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@coopdigital/foundations-forms/-/foundations-forms-3.1.3.tgz",
-      "integrity": "sha512-Zk2QROaRdCTV2oiLhAC21OqQyokTaNEMW8wlnu3ioDA1EOUKcQbuKGTJM3qcTnknf3JNfhdDVFsWD7R6ygIQ1w==",
-      "dev": true
+      "integrity": "sha512-Zk2QROaRdCTV2oiLhAC21OqQyokTaNEMW8wlnu3ioDA1EOUKcQbuKGTJM3qcTnknf3JNfhdDVFsWD7R6ygIQ1w=="
     },
     "@coopdigital/foundations-global": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@coopdigital/foundations-global/-/foundations-global-3.1.3.tgz",
-      "integrity": "sha512-LLyU1+bTUNEx4Vw1mTgFmGjoMzCcFNNCIe1D632H+UA+tq+6K1kqaFmkfggnp1zq2RJflvkoGxECQcBz5HeZbg==",
-      "dev": true
+      "integrity": "sha512-LLyU1+bTUNEx4Vw1mTgFmGjoMzCcFNNCIe1D632H+UA+tq+6K1kqaFmkfggnp1zq2RJflvkoGxECQcBz5HeZbg=="
     },
     "@coopdigital/foundations-grid": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@coopdigital/foundations-grid/-/foundations-grid-2.0.3.tgz",
-      "integrity": "sha512-THG/QXpwuVubARDQzbyW1TOaC+RYzeRu+qwI5hkNF1kT/sdJk2uWiWucj+n6pleNK8gaHOzppm7xVqAAPwJnZw==",
-      "dev": true
+      "integrity": "sha512-THG/QXpwuVubARDQzbyW1TOaC+RYzeRu+qwI5hkNF1kT/sdJk2uWiWucj+n6pleNK8gaHOzppm7xVqAAPwJnZw=="
     },
     "@coopdigital/foundations-layout": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@coopdigital/foundations-layout/-/foundations-layout-3.1.3.tgz",
-      "integrity": "sha512-tQmIY2uGAU8FlGfLS6yCo6LEqqYiTICDbGhfLXdyXBYRMmBX034pCTpTKxUnGU7M++pKszbNNz9ihCv1P09EZw==",
-      "dev": true
+      "integrity": "sha512-tQmIY2uGAU8FlGfLS6yCo6LEqqYiTICDbGhfLXdyXBYRMmBX034pCTpTKxUnGU7M++pKszbNNz9ihCv1P09EZw=="
     },
     "@coopdigital/foundations-tables": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@coopdigital/foundations-tables/-/foundations-tables-2.1.3.tgz",
-      "integrity": "sha512-ZNqASJ9Fh6EKEcJrtQgOQSxOH8mp/Ql2slpvHAimFdklFbp7ae1kS/z/C0cHDwr+n5XApPycN//HkUxLwhuiGA==",
-      "dev": true
+      "integrity": "sha512-ZNqASJ9Fh6EKEcJrtQgOQSxOH8mp/Ql2slpvHAimFdklFbp7ae1kS/z/C0cHDwr+n5XApPycN//HkUxLwhuiGA=="
     },
     "@coopdigital/foundations-typography": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@coopdigital/foundations-typography/-/foundations-typography-4.1.3.tgz",
-      "integrity": "sha512-7vGNB3UqHredYR5X3Q6yq9gfEUF/q2F7kfFiN+MO9hsbLWlPcItO6sJZyA7PK8EhRE91U9MePOgFK98QTQDTHw==",
-      "dev": true
+      "integrity": "sha512-7vGNB3UqHredYR5X3Q6yq9gfEUF/q2F7kfFiN+MO9hsbLWlPcItO6sJZyA7PK8EhRE91U9MePOgFK98QTQDTHw=="
     },
     "@coopdigital/foundations-vars": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@coopdigital/foundations-vars/-/foundations-vars-3.1.2.tgz",
-      "integrity": "sha512-TwT4E15FmBmemQZTmt3DNWIv6w28aemnSGwFdEFQ7Ex1tf4bvM8O65Vfu37Dd6oIA2E38yQqiLy3PGsbzTqDUw==",
-      "dev": true
+      "integrity": "sha512-TwT4E15FmBmemQZTmt3DNWIv6w28aemnSGwFdEFQ7Ex1tf4bvM8O65Vfu37Dd6oIA2E38yQqiLy3PGsbzTqDUw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -2061,6 +2052,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
       "dev": true
+    },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
     "nth-check": {
       "version": "1.0.2",

--- a/packages/css-foundations/package.json
+++ b/packages/css-foundations/package.json
@@ -20,7 +20,7 @@
     "url": "github:coopdigital/coop-frontend",
     "directory": "packages/css-foundations"
   },
-  "devDependencies": {
+  "dependencies": {
     "@coopdigital/foundations-buttons": "^2.1.3",
     "@coopdigital/foundations-colors": "^2.1.3",
     "@coopdigital/foundations-forms": "^3.1.3",
@@ -30,6 +30,9 @@
     "@coopdigital/foundations-tables": "^2.1.3",
     "@coopdigital/foundations-typography": "^4.1.3",
     "@coopdigital/foundations-vars": "^3.1.2",
+    "normalize.css": "^8.0.1"
+  },
+  "devDependencies": {
     "autoprefixer": "^9.8.5",
     "cssnano": "^4.1.10",
     "postcss": "^7.0.32",

--- a/packages/foundations-buttons/package.json
+++ b/packages/foundations-buttons/package.json
@@ -41,5 +41,8 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "gitHead": "4f6dd72bd513475b22840730c22185415f50af8f"
 }

--- a/packages/foundations-colors/package.json
+++ b/packages/foundations-colors/package.json
@@ -36,5 +36,8 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "gitHead": "4f6dd72bd513475b22840730c22185415f50af8f"
 }

--- a/packages/foundations-forms/package.json
+++ b/packages/foundations-forms/package.json
@@ -36,5 +36,8 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "gitHead": "4f6dd72bd513475b22840730c22185415f50af8f"
 }

--- a/packages/foundations-global/package.json
+++ b/packages/foundations-global/package.json
@@ -36,5 +36,8 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "gitHead": "4f6dd72bd513475b22840730c22185415f50af8f"
 }

--- a/packages/foundations-layout/package.json
+++ b/packages/foundations-layout/package.json
@@ -36,5 +36,8 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "gitHead": "4f6dd72bd513475b22840730c22185415f50af8f"
 }

--- a/packages/foundations-tables/package.json
+++ b/packages/foundations-tables/package.json
@@ -36,5 +36,8 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "gitHead": "4f6dd72bd513475b22840730c22185415f50af8f"
 }

--- a/packages/foundations-typography/package.json
+++ b/packages/foundations-typography/package.json
@@ -36,5 +36,8 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "gitHead": "4f6dd72bd513475b22840730c22185415f50af8f"
 }

--- a/packages/shared-component--editorialCard/package.json
+++ b/packages/shared-component--editorialCard/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--editorialCard/issues"
   },

--- a/packages/shared-component--featureCard/package.json
+++ b/packages/shared-component--featureCard/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--featureCard/issues"
   },

--- a/packages/shared-component--hero/package.json
+++ b/packages/shared-component--hero/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--hero/issues"
   },

--- a/packages/shared-component--image/package.json
+++ b/packages/shared-component--image/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--image/issues"
   },

--- a/packages/shared-component--linkList/package.json
+++ b/packages/shared-component--linkList/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--linkList/issues"
   },

--- a/packages/shared-component--membership/package.json
+++ b/packages/shared-component--membership/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--membership/issues"
   },

--- a/packages/shared-component--offers/package.json
+++ b/packages/shared-component--offers/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--offers/issues"
   },

--- a/packages/shared-component--postcode/package.json
+++ b/packages/shared-component--postcode/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--postcode/issues"
   },

--- a/packages/shared-component--signpost/package.json
+++ b/packages/shared-component--signpost/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--signpost/issues"
   },

--- a/packages/shared-component--statement/package.json
+++ b/packages/shared-component--statement/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--statement/issues"
   },

--- a/packages/shared-component--text/package.json
+++ b/packages/shared-component--text/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--text/issues"
   },

--- a/packages/shared-component--video/package.json
+++ b/packages/shared-component--video/package.json
@@ -36,6 +36,9 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.2"
   },
+  "peerDependencies": {
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
+  },
   "bugs": {
     "url": "https://github.com/coopdigital/shared-component--video/issues"
   },


### PR DESCRIPTION
This PR fixes two scenarios:

### Identity `dependencies` and `peerDependencies`
For example the **@coopdigital/component-notification--alert** package should add:

```json
"dependencies": {
  "@coopdigital/component-notification": "^1.0.8"
},
"peerDependencies": {
  "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
}
```

This ensures we correctly extend the **component-notification** package, but allow an already-installed or `npm link` version of `@coopdigital/foundations-vars` to be shared without installing it multiple times.

### Other missing dependencies
For Heroku prototypes, it's common to only install the foundations package:

```console
npm install @coopdigital/css-foundations
```

But you might notice that PostCSS builds that touch the _source_ PostCSS files (e.g. **gulp-postcss**) can't find the various child packages that their source files require, e.g.

```
[12:53:04] Error in plugin "gulp-postcss"
Message:
    Failed to find '@coopdigital/foundations-buttons'
  in [node_modules/@coopdigital/css-foundations/src]
Details:
    fileName: src/_css/main.css
    domainEmitter: [object Object]
    domain: [object Object]
    domainThrown: false

Stack:
Error: Failed to find '@coopdigital/foundations-buttons'
```

We can fix this by identifying all the other packages that are needed:

```
"dependencies": {
  "@coopdigital/foundations-buttons": "^2.1.3",
  "@coopdigital/foundations-colors": "^2.1.3",
  "@coopdigital/foundations-forms": "^3.1.3",
  "@coopdigital/foundations-global": "^3.1.3",
  "@coopdigital/foundations-grid": "^2.0.3",
  "@coopdigital/foundations-layout": "^3.1.3",
  "@coopdigital/foundations-tables": "^2.1.3",
  "@coopdigital/foundations-typography": "^4.1.3",
  "@coopdigital/foundations-vars": "^3.1.2",
  "normalize.css": "^8.0.1"
},
```

Previously they were wrongly marked as `devDependencies` 🎉 