### PR TITLE
Add initial new form field styles and examples

### DIFF
--- a/design-system/gulpfile.js
+++ b/design-system/gulpfile.js
@@ -157,6 +157,7 @@ function watch(done) {
  */
 function serve(done) {
   connect.server({
+    host: '0.0.0.0',
     port: 9000,
     root: 'build',
     livereload: true

--- a/design-system/src/_data/contentful/spaces/design-system-content.yaml
+++ b/design-system/src/_data/contentful/spaces/design-system-content.yaml
@@ -17,16 +17,16 @@ designPattern:
 - sys:
     id: lAvhQFgf60gYgaGeSyS2k
     created_at: !ruby/object:DateTime 2018-11-08 19:53:47.846000000 Z
-    updated_at: !ruby/object:DateTime 2020-07-23 15:33:32.741000000 Z
+    updated_at: !ruby/object:DateTime 2020-08-27 09:28:13.309000000 Z
     content_type_id: designPattern
-    revision: 5
+    revision: 6
   title: Logo
   status: live
   github_url: https://www.npmjs.com/package/@coopdigital/foundations-global
   npm_url: https://github.com/coopdigital/foundations-global
   introduction: The Cloverleaf Symbol was created in 1968 for project facelift, when
     all the Co-op societies united under one banner. We now use a modernised version
-    that optimised for modern production methods.
+    that optimised for modern production methods
   design_and_content_documentation: |-
     The logo should:
 
@@ -481,13 +481,13 @@ designPattern:
 - sys:
     id: 59IgUOk2tyqWmQeEAuEu8C
     created_at: !ruby/object:DateTime 2018-11-16 20:55:59.171000000 Z
-    updated_at: !ruby/object:DateTime 2019-10-14 11:03:13.759000000 Z
+    updated_at: !ruby/object:DateTime 2020-08-27 14:58:33.032000000 Z
     content_type_id: designPattern
-    revision: 8
+    revision: 9
   title: Editorial card
   status: live
-  github_url: https://github.com/coopdigital/coop-frontend/tree/master/packages/component-card
-  npm_url: https://www.npmjs.com/package/@coopdigital/component-card
+  github_url: https://github.com/coopdigital/coop-frontend/tree/master/packages/shared-component--editorialCard
+  npm_url: https://www.npmjs.com/package/@coopdigital/shared-component--editorialcard
   introduction: 'An editorial card contains a small piece of prose information on
     one subject that people can get more information about by tapping or clicking
     on the card.   '
@@ -1206,9 +1206,9 @@ page:
 - sys:
     id: 2dwjl9DDVOEK8WEkwss0Mc
     created_at: !ruby/object:DateTime 2018-10-24 13:37:19.171000000 Z
-    updated_at: !ruby/object:DateTime 2020-08-12 08:27:46.068000000 Z
+    updated_at: !ruby/object:DateTime 2020-08-26 08:05:08.719000000 Z
     content_type_id: page
-    revision: 4
+    revision: 5
   title: Accessibility guidelines
   introduction: |-
     Do not design for difference, design so that no one feels different.
@@ -1313,7 +1313,8 @@ page:
     - have little or no knowledge about the subject you're writing about
     - not be confident using a computer or mobile device
     - have their own situation, insecurities and struggles
-    - All users deserve our consideration.
+
+    All users deserve our consideration.
 
     There's guidance on writing clear, understandable, accessible content in our [content guidelines](https://coop-design-system.herokuapp.com/content.html).
 

--- a/design-system/src/_includes/pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html
@@ -1,35 +1,168 @@
 
-<div class="coop-form__row">
-    <fieldset class="coop-c-form-choice">
-        <legend class="coop-c-form-choice__legend">Do you own:</legend>
-        <div class="coop-c-form-choice">
-            <input type="checkbox" name="option" id="checkbox" value="2" class="coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-            <label for="checkbox" class="coop-c-form-choice__label">a business</label>
-        </div>
-        <div class="coop-c-form-choice">
-            <input type="checkbox" name="option" id="checkbox-2" value="2" class="coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-            <label for="checkbox-2" class="coop-c-form-choice__label">agricultural property</label>
-        </div>
-        <div class="coop-c-form-choice">
-            <input type="checkbox" name="option" id="checkbox-3" value="2" class="coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-            <label for="checkbox-3" class="coop-c-form-choice__label">foreign property</label>
-        </div>
-        <div class="coop-c-form-choice">
-            <input type="checkbox" name="option" id="checkbox-4" value="2" class="coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-            <label for="checkbox-4" class="coop-c-form-choice__label">trademarks or patents</label>
-        </div>
-    </fieldset>
-</div>
-<div class="coop-form__row">
-    <fieldset class="coop-c-form-choice">
-        <legend class="coop-c-form-choice__legend">Type of delivery</legend>
-        <div class="coop-c-form-choice">
-            <input type="radio" name="option" id="option-1" value="1" class="coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-            <label class="coop-c-form-choice__label" for="option-1">Free delivery</label>
-        </div>
-        <div class="coop-c-form-choice">
-            <input type="radio" name="option" id="option-2" value="2" class="coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-            <label class="coop-c-form-choice__label" for="option-2">Next day delivery — £4.99</label>
-        </div>
-    </fieldset>
-</div>
+<!-- Checkboxes and radios -->
+<form class="coop-form coop-c-form-choice">
+    <h3>Checkboxes and radios</h3>
+
+    <div class="coop-form__row">
+        <fieldset class="coop-c-form-choice">
+            <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-1" id="checkbox-1-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-1-1" class="coop-form__label coop-c-form-choice__label">a business</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-1" id="checkbox-1-2" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-1-2" class="coop-form__label coop-c-form-choice__label">agricultural property</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-1" id="checkbox-1-3" value="3" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-1-3" class="coop-form__label coop-c-form-choice__label">foreign property</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-1" id="checkbox-1-4" value="4" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-1-4" class="coop-form__label coop-c-form-choice__label">trademarks or patents</label>
+            </div>
+        </fieldset>
+    </div>
+    <div class="coop-form__row">
+        <fieldset class="coop-c-form-choice">
+            <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
+            <div class="coop-c-form-choice">
+                <input type="radio" name="radio-1" id="radio-1-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
+                <label class="coop-form__label coop-c-form-choice__label" for="radio-1-1">Free delivery</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="radio" name="radio-1" id="radio-1-2" value="2" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
+                <label class="coop-form__label coop-c-form-choice__label" for="radio-1-2">Next day delivery — £4.99</label>
+            </div>
+        </fieldset>
+    </div>
+</form>
+
+<!-- Checkboxes and radios with hint -->
+<form class="coop-form coop-c-form-choice">
+    <h3>Checkboxes and radios with hint</h3>
+
+    <div class="coop-form__row">
+        <fieldset class="coop-c-form-choice" aria-describedby="checkbox-2-hint">
+            <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
+            <p id="checkbox-2-hint" class="coop-form__hint coop-c-form-choice__hint">Select all that apply</p>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-2" id="checkbox-2-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-2-1" class="coop-form__label coop-c-form-choice__label">a business</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-2" id="checkbox-2-2" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-2-2" class="coop-form__label coop-c-form-choice__label">agricultural property</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-2" id="checkbox-2-3" value="3" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-2-3" class="coop-form__label coop-c-form-choice__label">foreign property</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-2" id="checkbox-2-4" value="4" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-2-4" class="coop-form__label coop-c-form-choice__label">trademarks or patents</label>
+            </div>
+        </fieldset>
+    </div>
+    <div class="coop-form__row">
+        <fieldset class="coop-c-form-choice" aria-describedby="radio-2-hint">
+            <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
+            <p id="radio-2-hint" class="coop-form__hint coop-c-form-choice__hint">Select only one option</p>
+            <div class="coop-c-form-choice">
+                <input type="radio" name="radio-2" id="radio-2-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
+                <label class="coop-form__label coop-c-form-choice__label" for="radio-2-1">Free delivery</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="radio" name="radio-2" id="radio-2-2" value="2" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
+                <label class="coop-form__label coop-c-form-choice__label" for="radio-2-2">Next day delivery — £4.99</label>
+            </div>
+        </fieldset>
+    </div>
+</form>
+
+<!-- Checkboxes and radios with error message -->
+<form class="coop-form coop-c-form-choice">
+    <h3>Checkboxes and radios with error message</h3>
+
+    <div class="coop-form__row coop-c-form-error">
+        <fieldset class="coop-c-form-choice" aria-describedby="checkbox-3-error">
+            <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
+            <p id="checkbox-3-error" class="coop-form__error coop-c-form-choice__error coop-c-form-error__text">Select options owned by you</p>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-3" id="checkbox-3-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-3-1" class="coop-form__label coop-c-form-choice__label">a business</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-3" id="checkbox-3-2" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-3-2" class="coop-form__label coop-c-form-choice__label">agricultural property</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-3" id="checkbox-3-3" value="3" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-3-3" class="coop-form__label coop-c-form-choice__label">foreign property</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-3" id="checkbox-3-4" value="4" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-3-4" class="coop-form__label coop-c-form-choice__label">trademarks or patents</label>
+            </div>
+        </fieldset>
+    </div>
+    <div class="coop-form__row coop-c-form-error">
+        <fieldset class="coop-c-form-choice" aria-describedby="radio-3-error">
+            <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
+            <p id="radio-3-error" class="coop-form__error coop-c-form-choice__error coop-c-form-error__text">Select type of delivery</p>
+            <div class="coop-c-form-choice">
+                <input type="radio" name="radio-3" id="radio-3-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
+                <label class="coop-form__label coop-c-form-choice__label" for="radio-3-1">Free delivery</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="radio" name="radio-3" id="radio-3-2" value="2" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
+                <label class="coop-form__label coop-c-form-choice__label" for="radio-3-2">Next day delivery — £4.99</label>
+            </div>
+        </fieldset>
+    </div>
+</form>
+
+<!-- Checkboxes and radios with hint and error message -->
+<form class="coop-form coop-c-form-choice">
+    <h3>Checkboxes and radios with hint and error message</h3>
+
+    <div class="coop-form__row">
+        <fieldset class="coop-c-form-choice" aria-describedby="checkbox-4-hint checkbox-4-error">
+            <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
+            <p id="checkbox-4-hint" class="coop-form__hint coop-c-form-choice__hint">Select all that apply</p>
+            <p id="checkbox-4-error" class="coop-form__error coop-c-form-choice__error coop-c-form-error__text">Select options owned by you</p>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-4" id="checkbox-4-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-4-1" class="coop-form__label coop-c-form-choice__label">a business</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-4" id="checkbox-4-2" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-4-2" class="coop-form__label coop-c-form-choice__label">agricultural property</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-4" id="checkbox-4-3" value="3" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-4-3" class="coop-form__label coop-c-form-choice__label">foreign property</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="checkbox" name="checkbox-4" id="checkbox-4-4" value="4" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
+                <label for="checkbox-4-4" class="coop-form__label coop-c-form-choice__label">trademarks or patents</label>
+            </div>
+        </fieldset>
+    </div>
+    <div class="coop-form__row">
+        <fieldset class="coop-c-form-choice" aria-describedby="radio-4-hint radio-4-error">
+            <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
+            <p id="radio-4-hint" class="coop-form__hint coop-c-form-choice__hint">Select only one option</p>
+            <p id="radio-4-error" class="coop-form__error coop-c-form-choice__error coop-c-form-error__text">Select type of delivery</p>
+            <div class="coop-c-form-choice">
+                <input type="radio" name="radio-4" id="radio-4-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
+                <label class="coop-form__label coop-c-form-choice__label" for="radio-4-1">Free delivery</label>
+            </div>
+            <div class="coop-c-form-choice">
+                <input type="radio" name="radio-4" id="radio-4-2" value="2" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
+                <label class="coop-form__label coop-c-form-choice__label" for="radio-4-2">Next day delivery — £4.99</label>
+            </div>
+        </fieldset>
+    </div>
+</form>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-input/input.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-input/input.html
@@ -1,3 +1,44 @@
 
-<label for="full-name" class="">Full name</label>
-<input type="text" name="full-name" id="full-name">
+<!-- Input -->
+<form class="coop-form">
+    <h3>Input</h3>
+
+    <div class="coop-form__row">
+        <label for="full-name-1" class="coop-form__label">Full name</label>
+        <input type="text" name="full-name-1" id="full-name-1" class="coop-form__field coop-form__input">
+    </div>
+</form>
+
+<!-- Input with hint -->
+<form class="coop-form">
+    <h3>Input with hint</h3>
+
+    <div class="coop-form__row">
+        <label for="full-name-2" class="coop-form__label">Full name</label>
+        <p id="full-name-2-hint" class="coop-form__hint">This is an example hint</p>
+        <input type="text" name="full-name-2" id="full-name-2" class="coop-form__field coop-form__input" aria-describedby="full-name-2-hint">
+    </div>
+</form>
+
+<!-- Input with error message -->
+<form class="coop-form">
+    <h3>Input with error message</h3>
+
+    <div class="coop-form__row coop-c-form-error">
+        <label for="full-name-3" class="coop-form__label">Full name</label>
+        <p id="full-name-3-error" class="coop-form__error coop-c-form-error__text">Enter your full name</p>
+        <input type="text" name="full-name-3" id="full-name-3" class="coop-form__field coop-form__input coop-form__invalid" aria-describedby="full-name-3-error">
+    </div>
+</form>
+
+<!-- Input with hint and error message -->
+<form class="coop-form">
+    <h3>Input with hint and error message</h3>
+
+    <div class="coop-form__row coop-c-form-error">
+        <label for="full-name-4" class="coop-form__label">Full name</label>
+        <p id="full-name-4-hint" class="coop-form__hint">This is an example hint</p>
+        <p id="full-name-4-error" class="coop-form__error coop-c-form-error__text">Enter your full name</p>
+        <input type="text" name="full-name-4" id="full-name-4" class="coop-form__field coop-form__input coop-form__invalid" aria-describedby="full-name-4-hint full-name-4-error">
+    </div>
+</form>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-select/select.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-select/select.html
@@ -1,7 +1,60 @@
 
-<label for="sortBy">Sort by:</label>
-<select id="sortBy">
-    <option data-contenttype="Price Sort" data-contentparent="Sort" data-linktext="Relevancy" value="live_global_product_search">Relevancy</option>
-    <option data-contenttype="Price Sort" data-contentparent="Sort" data-linktext="Price: Low to high" value="live_global_product_search_price_asc">Price: Low to high</option>
-    <option data-contenttype="Price Sort" data-contentparent="Sort" data-linktext="Price: High to low" value="live_global_product_search_price_desc">Price: High to low</option>
-</select>
+<!-- Select -->
+<form class="coop-form">
+    <h3>Select</h3>
+
+    <div class="coop-form__row">
+        <label class="coop-form__label" for="sort-by-1">Sort by:</label>
+        <select id="sort-by-1" class="coop-form__field coop-form__select">
+            <option value="relevancy">Relevancy</option>
+            <option value="price-asc">Price: Low to high</option>
+            <option value="price-desc">Price: High to low</option>
+        </select>
+    </div>
+</form>
+
+<!-- Select with hint -->
+<form class="coop-form">
+    <h3>Select with hint</h3>
+
+    <div class="coop-form__row">
+        <label class="coop-form__label" for="sort-by-2">Sort by:</label>
+        <p id="sort-by-2-hint" class="coop-form__hint">This is an example hint</p>
+        <select id="sort-by-2" class="coop-form__field coop-form__select" aria-describedby="sort-by-2-hint">
+            <option value="relevancy">Relevancy</option>
+            <option value="price-asc">Price: Low to high</option>
+            <option value="price-desc">Price: High to low</option>
+        </select>
+    </div>
+</form>
+
+<!-- Select with error message -->
+<form class="coop-form">
+    <h3>Select with error message</h3>
+
+    <div class="coop-form__row coop-c-form-error">
+        <label class="coop-form__label" for="sort-by-3">Sort by:</label>
+        <p id="sort-by-3-error" class="coop-form__error coop-c-form-error__text">Select a sort by option</p>
+        <select id="sort-by-3" class="coop-form__field coop-form__select coop-form__invalid" aria-describedby="sort-by-3-error">
+            <option value="relevancy">Relevancy</option>
+            <option value="price-asc">Price: Low to high</option>
+            <option value="price-desc">Price: High to low</option>
+        </select>
+    </div>
+</form>
+
+<!-- Select with hint and error message -->
+<form class="coop-form">
+    <h3>Select with hint and error message</h3>
+
+    <div class="coop-form__row coop-c-form-error">
+        <label class="coop-form__label" for="sort-by-4">Sort by:</label>
+        <p id="sort-by-4-hint" class="coop-form__hint">This is an example hint</p>
+        <p id="sort-by-4-error" class="coop-form__error coop-c-form-error__text">Select a sort by option</p>
+        <select id="sort-by-4" class="coop-form__field coop-form__select coop-form__invalid" aria-describedby="sort-by-4-hint sort-by-4-error">
+            <option value="relevancy">Relevancy</option>
+            <option value="price-asc">Price: Low to high</option>
+            <option value="price-desc">Price: High to low</option>
+        </select>
+    </div>
+</form>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-textarea/textarea.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-textarea/textarea.html
@@ -1,3 +1,44 @@
 
-<label for="feedback">Tell us what you liked or what we can improve</label>
-<textarea id="feedback" cols="30" rows="4"></textarea>
+<!-- Textarea -->
+<form class="coop-form">
+    <h3>Textarea</h3>
+
+    <div class="coop-form__row">
+        <label for="feedback-1" class="coop-form__label">Tell us what you liked or what we can improve</label>
+        <textarea id="feedback-1" cols="30" rows="4" class="coop-form__field coop-form__textarea"></textarea>
+    </div>
+</form>
+
+<!-- Textarea with hint -->
+<form class="coop-form">
+    <h3>Textarea with hint</h3>
+
+    <div class="coop-form__row">
+        <label for="feedback-2" class="coop-form__label">Tell us what you liked or what we can improve</label>
+        <p id="feedback-2-hint" class="coop-form__hint">This is an example hint</p>
+        <textarea id="feedback-2" cols="30" rows="4" class="coop-form__field coop-form__textarea" aria-describedby="feedback-2-hint"></textarea>
+    </div>
+</form>
+
+<!-- Textarea with error message -->
+<form class="coop-form">
+    <h3>Textarea with hint</h3>
+
+    <div class="coop-form__row coop-c-form-error">
+        <label for="feedback-3" class="coop-form__label">Tell us what you liked or what we can improve</label>
+        <p id="feedback-3-error" class="coop-form__error coop-c-form-error__text">Enter your feedback</p>
+        <textarea id="feedback-3" cols="30" rows="4" class="coop-form__field coop-form__textarea coop-form__invalid" aria-describedby="feedback-3-error"></textarea>
+    </div>
+</form>
+
+<!-- Textarea with hint and error message -->
+<form class="coop-form">
+    <h3>Textarea with hint and error message</h3>
+
+    <div class="coop-form__row coop-c-form-error">
+        <label for="feedback-4" class="coop-form__label">Tell us what you liked or what we can improve</label>
+        <p id="feedback-4-hint" class="coop-form__hint">This is an example hint</p>
+        <p id="feedback-4-error" class="coop-form__error coop-c-form-error__text">Enter your feedback</p>
+        <textarea id="feedback-4" cols="30" rows="4" class="coop-form__field coop-form__textarea coop-form__invalid" aria-describedby="feedback-4-hint feedback-4-error"></textarea>
+    </div>
+</form>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-validation/validation.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-validation/validation.html
@@ -10,13 +10,13 @@
     </div>
     <div class="coop-form__row coop-c-form-error">
         <label class="coop-form__label" for="client-name">Your full name</label>
-        <p id="client-name-error" class="coop-c-form-error__text">Enter your full name</p>
+        <p id="client-name-error" class="coop-form__error coop-c-form-error__text">Enter your full name</p>
         <input class="coop-form__field coop-form__input coop-form__invalid" type="text" value="" name="client[name]" id="client-name" aria-describedby="client-name-error">
     </div>
     <div class="coop-form__row coop-c-form-error">
         <label class="coop-form__label" for="client-email-address">Your email address</label>
-        <p id="client-email-address-hint" class="coop-label__hint">We’ll only use this to contact you about your will.</p>
-        <p id="client-email-address-error" class="coop-c-form-error__text">Enter an email address</p>
+        <p id="client-email-address-hint" class="coop-form__hint">We’ll only use this to contact you about your will.</p>
+        <p id="client-email-address-error" class="coop-form__error coop-c-form-error__text">Enter an email address</p>
         <input class="coop-form__field coop-form__input coop-form__invalid" type="email" value="" name="client[email_address]" id="client-email-address" aria-describedby="client-email-address-hint client-email-address-error">
     </div>
 </form>

--- a/design-system/src/pattern-library/examples/index.html
+++ b/design-system/src/pattern-library/examples/index.html
@@ -1282,91 +1282,20 @@ id: examples
 <div class="coop-u-margin-b-64">
     <h2>Forms</h2>
     <div class="coop-u-margin-b-32">
-        <h3>Text input</h3>
+        {% include pattern-library/foundations/foundations-input/input.html %}
+    </div>
+    <div class="coop-u-margin-b-32">
         <div class="coop-l-grid">
             <div class="coop-l-grid__item coop-l-grid__item--large-6">
-                <form class="coop-form">
-                    <div class="coop-form__row">
-                        <label for="full-name" class="coop-form__label">Full name</label>
-                        <p id="full-name-hint" class="coop-label__hint">This is an example hint</p>
-                        <input type="text" name="full-name" id="full-name" class="coop-form__field coop-form__input" aria-describedby="full-name-hint">
-                    </div>
-                </form>
+                {% include pattern-library/foundations/foundations-textarea/textarea.html %}
             </div>
         </div>
     </div>
     <div class="coop-u-margin-b-32">
-        <h3>Text area</h3>
-        <div class="coop-l-grid">
-            <div class="coop-l-grid__item coop-l-grid__item--large-6">
-                <form class="coop-form">
-                    <div class="coop-form__row">
-                        <label for="feedback" class="coop-form__label">Tell us what you liked or what we can improve</label>
-                        <p id="feedback-hint" class="coop-label__hint">This is an example hint</p>
-                        <textarea id="feedback" cols="30" rows="4" class="coop-form__field coop-form__textarea" aria-describedby="feedback-hint"></textarea>
-                    </div>
-                </form>
-            </div>
-        </div>
+        {% include pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html %}
     </div>
     <div class="coop-u-margin-b-32">
-        <h3>Checkboxes</h3>
-        <form class="coop-form coop-c-form-choice">
-            <fieldset class="coop-c-form-choice">
-                <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
-                <div class="coop-form__row coop-c-form-choice">
-                    <input type="checkbox" name="option" id="checkbox-1" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                    <label for="checkbox-1" class="coop-form__label coop-c-form-choice__label">a business</label>
-                </div>
-                <div class="coop-form__row coop-c-form-choice">
-                    <input type="checkbox" name="option" id="checkbox-2" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                    <label for="checkbox-2" class="coop-form__label coop-c-form-choice__label">agricultural property</label>
-                </div>
-                <div class="coop-form__row coop-c-form-choice">
-                    <input type="checkbox" name="option" id="checkbox-3" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                    <label for="checkbox-3" class="coop-form__label coop-c-form-choice__label">foreign property</label>
-                </div>
-                <div class="coop-form__row coop-c-form-choice">
-                    <input type="checkbox" name="option" id="checkbox-4" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                    <label for="checkbox-4" class="coop-form__label coop-c-form-choice__label">trademarks or patents</label>
-                </div>
-            </fieldset>
-        </form>
-    </div>
-    <div class="coop-u-margin-b-32">
-        <h3>Radios</h3>
-        <form class="coop-form coop-c-form-choice">
-            <fieldset class="coop-c-form-choice">
-                <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
-                <div class="coop-form__row coop-c-form-choice">
-                    <input type="radio" name="option" id="option-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-                    <label class="coop-form__label coop-c-form-choice__label" for="option-1">Free delivery</label>
-                </div>
-                <div class="coop-form__row coop-c-form-choice">
-                    <input type="radio" name="option" id="option-2" value="2" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-                    <label class="coop-form__label coop-c-form-choice__label" for="option-2">Next day delivery — £4.99</label>
-                </div>
-            </fieldset>
-        </form>
-    </div>
-    <div class="coop-u-margin-b-32">
-        <h3>Select</h3>
-        <p>We do not advise the use of select because research shows that some users find selects very difficult to use.</p>
-        <p>Watch a video about how some <a href="https://www.youtube.com/watch?v=CUkMCQR4TpY">users struggle with selects</a>.</p>
-        <div class="coop-l-grid">
-            <div class="coop-l-grid__item coop-l-grid__item--large-6">
-                <form class="coop-form">
-                    <div class="coop-form__row">
-                        <label for="sortBy" class="coop-form__label">Sort by:</label>
-                        <select id="sortBy" class="coop-form__field coop-form__select">
-                            <option data-contenttype="Price Sort" data-contentparent="Sort" data-linktext="Relevancy" value="live_global_product_search">Relevancy</option>
-                            <option data-contenttype="Price Sort" data-contentparent="Sort" data-linktext="Price: Low to high" value="live_global_product_search_price_asc">Price: Low to high</option>
-                            <option data-contenttype="Price Sort" data-contentparent="Sort" data-linktext="Price: High to low" value="live_global_product_search_price_desc">Price: High to low</option>
-                        </select>
-                    </div>
-                </form>
-            </div>
-        </div>
+        {% include pattern-library/foundations/foundations-select/select.html %}
     </div>
     <div class="coop-u-margin-b-32">
         <h3>Buttons</h3>

--- a/design-system/src/pattern-library/foundations/select.html
+++ b/design-system/src/pattern-library/foundations/select.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 body-page-class: dm-dark
-title: Textarea
+title: Select dropdown
 id: pattern-library
 ---
 <article>

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -86,7 +86,6 @@ textarea,
 .coop-form__textarea {
   display: block;
   width: 100%;
-  padding: var(--spacing-base--1-4);
   background: var(--color-white);
   border: 1px solid;
   border-color: var(--color-grey-dark);
@@ -123,9 +122,25 @@ textarea,
   }
 }
 
+input,
+.coop-form__input {
+  height: 3.25rem; /* 52px / 16 */
+  padding: var(--spacing-8) calc(var(--spacing-8) * 1.5);
+
+  @media (--mq-medium) {
+    height: 3.75rem; /* 60px / 16 */
+  }
+}
+
 textarea,
 .coop-form__textarea {
+  min-height: 3.25rem; /* 52px / 16 */
+  padding: calc(var(--spacing-8) * 1.75) calc(var(--spacing-8) * 1.5);
   resize: vertical;
+
+  @media (--mq-medium) {
+    min-height: 3.75rem; /* 60px / 16 */
+  }
 }
 
 select,

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -285,17 +285,15 @@ input[type="radio"],
 }
 
 .coop-c-form-choice__input:focus + .coop-c-form-choice__label::before {
-  background: #ffffff;
-  border-color: #000000;
   outline-offset: 3px;
   outline: 2px solid var(--color-link--focus);
-  -webkit-transition: none;
   transition: none;
 }
 
 .coop-c-form-choice__input + .coop-c-form-choice__label::before {
   content: "";
   border: 2px solid;
+  border-color: var(--color-black);
   background: transparent;
   width: 25px;
   height: 25px;

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -146,11 +146,11 @@ textarea,
 select,
 .coop-form__select {
   appearance: menulist;
-  height: 2.8175em;
+  height: 3.25rem; /* 52px / 16 */
   cursor: pointer;
   display: block;
   width: 100%;
-  padding: var(--spacing-base--1-6) var(--spacing-base--1-8);
+  padding: var(--spacing-8) calc(var(--spacing-8) * 1.5);
   background: var(--color-white);
   border: 1px solid;
   border-color: var(--color-grey-dark);
@@ -183,6 +183,7 @@ select,
 
   @media (--mq-medium) {
     font-size: var(--type-body-l);
+    height: 3.75rem; /* 60px / 16 */
   }
 }
 

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -7,7 +7,7 @@
 }
 
 .coop-form__row {
-  margin-bottom: var(--spacing-base--1-2);
+  margin-bottom: var(--spacing-base--3-4);
 
   &::before,
   &::after {
@@ -27,16 +27,17 @@ label,
   line-height: var(--type-line-height);
   font-weight: 500;
   display: block;
-  margin: 0 0 calc(var(--spacing-base--1-4) / 2);
+  margin: 0 0 var(--spacing-8);
 
   @media (--mq-medium) {
     font-size: var(--type-body-l);
   }
 }
 
-.coop-label__hint {
+.coop-label__hint,
+.coop-form__hint {
   display: block;
-  margin: 0 0 calc(var(--spacing-base--1-4) / 2);
+  margin: 0 0 var(--spacing-8);
   color: var(--color-grey-dark);
   font-family: var(--font-family);
   font-style: normal;
@@ -50,7 +51,8 @@ label,
 }
 
 label + .coop-label__hint,
-.coop-form__label + .coop-label__hint {
+.coop-form__label + .coop-label__hint,
+.coop-form__label + .coop-form__hint {
   margin-top: calc(var(--spacing-base--1-4) / -2);
 }
 
@@ -231,20 +233,18 @@ input[type="radio"],
 }
 
 .coop-form__error {
-  position: relative;
-  margin: 0.5rem 0;
-  padding-left: 2rem;
+  margin: 0 0 var(--spacing-8);
   color: var(--color-red-mid);
+}
 
-  &::before {
-    position: absolute;
-    left: 0;
-    font-size: 1.5rem;
-  }
+label + .coop-form__error,
+.coop-form__label + .coop-form__error {
+  margin-top: calc(var(--spacing-8) * -1);
+}
 
-  &:last-child {
-    margin-bottom: 0.5rem;
-  }
+.coop-label__hint + .coop-form__error,
+.coop-form__hint + .coop-form__error {
+  margin-top: var(--spacing-16);
 }
 
 .coop-c-form-choice {
@@ -282,6 +282,15 @@ input[type="radio"],
   line-height: 1.6;
   -ms-touch-action: manipulation;
   touch-action: manipulation;
+}
+
+.coop-c-form-choice__hint,
+.coop-c-form-choice__error {
+  margin-bottom: var(--spacing-4);
+
+  @media (--mq-medium) {
+    margin-bottom: var(--spacing-8);
+  }
 }
 
 .coop-c-form-choice__input:focus + .coop-c-form-choice__label::before {
@@ -365,5 +374,4 @@ input[type="radio"],
 
 .coop-c-form-error__text {
   color: var(--color-red-error);
-  margin-bottom: 0;
 }

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -87,8 +87,9 @@ textarea,
   display: block;
   width: 100%;
   background: var(--color-white);
-  border: 1px solid;
+  border: 2px solid;
   border-color: var(--color-grey-dark);
+  border-radius: 5px;
   color: var(--color-text);
   outline: 0;
   transition: border-color 0.3s ease-in-out;
@@ -152,7 +153,8 @@ select,
   width: 100%;
   padding: var(--spacing-8) calc(var(--spacing-8) * 1.5);
   background: var(--color-white);
-  border: 1px solid;
+  border: 2px solid;
+  border-radius: 5px;
   border-color: var(--color-grey-dark);
   color: var(--color-text);
   outline: 0;

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -92,7 +92,7 @@ textarea,
   border-color: var(--color-grey-dark);
   color: var(--color-text);
   outline: 0;
-  transition: all 0.3s ease-in-out;
+  transition: border-color 0.3s ease-in-out;
   font-size: var(--type-body-s);
   line-height: var(--type-line-height);
 
@@ -141,7 +141,7 @@ select,
   border-color: var(--color-grey-dark);
   color: var(--color-text);
   outline: 0;
-  transition: all 0.3s ease-in-out;
+  transition: border-color 0.3s ease-in-out;
   font-size: var(--type-body-s);
 
   &:focus {


### PR DESCRIPTION
What has the Design System missed for ages?

Examples of how to do:

1. Form fields with hints
2. Form fields with errors
3. Form fields with hints AND errors 😆 

I've added them in this PR including how we wire them up with `aria-describedby`, plus the new **2px rounded border** styles coming for form fields (text inputs, text areas, dropdown menus).

This also makes form inputs slightly taller so they're perfectly aligned with the 44px by 44px minimum button sizes (See [WCAG 2.2 Success Criterion 2.5.8 Pointer Target Spacing](https://www.w3.org/TR/WCAG22/#pointer-target-spacing)) from PR https://github.com/coopdigital/coop-frontend/pull/149.

All of these are now on the kitchen sink page too 🎉 

### Before (the problem)
Looks like inputs have been left behind

* Thin 1px outline
* Height doesn't align with buttons
* Lack of border radius doesn't complement the button

![Screenshot 2020-09-01 at 16 19 48](https://user-images.githubusercontent.com/415517/91871000-05242000-ec6f-11ea-914f-61e8d74b7846.png)

### After (the solution)

![Form examples](https://user-images.githubusercontent.com/415517/91869238-8b3f6700-ec6d-11ea-8a16-06645da6ef33.png)

![Input examples](https://user-images.githubusercontent.com/415517/91869546-ec673a80-ec6d-11ea-9814-44b6cd65473b.png)
