### PR TITLE
Remove duplicate error/hint classes

### DIFF
--- a/design-system/src/_includes/pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html
@@ -85,10 +85,10 @@
 <form class="coop-form coop-c-form-choice">
     <h3>Checkboxes and radios with error message</h3>
 
-    <div class="coop-form__row coop-c-form-error">
+    <div class="coop-form__row">
         <fieldset class="coop-c-form-choice" aria-describedby="checkbox-3-error">
             <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
-            <p id="checkbox-3-error" class="coop-form__error coop-c-form-choice__error coop-c-form-error__text">Select options owned by you</p>
+            <p id="checkbox-3-error" class="coop-form__error coop-c-form-choice__error">Select options owned by you</p>
             <div class="coop-c-form-choice">
                 <input type="checkbox" name="checkbox-3" id="checkbox-3-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
                 <label for="checkbox-3-1" class="coop-form__label coop-c-form-choice__label">a business</label>
@@ -107,10 +107,10 @@
             </div>
         </fieldset>
     </div>
-    <div class="coop-form__row coop-c-form-error">
+    <div class="coop-form__row">
         <fieldset class="coop-c-form-choice" aria-describedby="radio-3-error">
             <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
-            <p id="radio-3-error" class="coop-form__error coop-c-form-choice__error coop-c-form-error__text">Select type of delivery</p>
+            <p id="radio-3-error" class="coop-form__error coop-c-form-choice__error">Select type of delivery</p>
             <div class="coop-c-form-choice">
                 <input type="radio" name="radio-3" id="radio-3-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
                 <label class="coop-form__label coop-c-form-choice__label" for="radio-3-1">Free delivery</label>
@@ -131,7 +131,7 @@
         <fieldset class="coop-c-form-choice" aria-describedby="checkbox-4-hint checkbox-4-error">
             <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
             <p id="checkbox-4-hint" class="coop-form__hint coop-c-form-choice__hint">Select all that apply</p>
-            <p id="checkbox-4-error" class="coop-form__error coop-c-form-choice__error coop-c-form-error__text">Select options owned by you</p>
+            <p id="checkbox-4-error" class="coop-form__error coop-c-form-choice__error">Select options owned by you</p>
             <div class="coop-c-form-choice">
                 <input type="checkbox" name="checkbox-4" id="checkbox-4-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
                 <label for="checkbox-4-1" class="coop-form__label coop-c-form-choice__label">a business</label>
@@ -154,7 +154,7 @@
         <fieldset class="coop-c-form-choice" aria-describedby="radio-4-hint radio-4-error">
             <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
             <p id="radio-4-hint" class="coop-form__hint coop-c-form-choice__hint">Select only one option</p>
-            <p id="radio-4-error" class="coop-form__error coop-c-form-choice__error coop-c-form-error__text">Select type of delivery</p>
+            <p id="radio-4-error" class="coop-form__error coop-c-form-choice__error">Select type of delivery</p>
             <div class="coop-c-form-choice">
                 <input type="radio" name="radio-4" id="radio-4-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
                 <label class="coop-form__label coop-c-form-choice__label" for="radio-4-1">Free delivery</label>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html
@@ -46,7 +46,7 @@
     <div class="coop-form__row">
         <fieldset class="coop-c-form-choice" aria-describedby="checkbox-2-hint">
             <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
-            <p id="checkbox-2-hint" class="coop-form__hint coop-c-form-choice__hint">Select all that apply</p>
+            <p id="checkbox-2-hint" class="coop-form__hint">Select all that apply</p>
             <div class="coop-c-form-choice">
                 <input type="checkbox" name="checkbox-2" id="checkbox-2-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
                 <label for="checkbox-2-1" class="coop-form__label coop-c-form-choice__label">a business</label>
@@ -68,7 +68,7 @@
     <div class="coop-form__row">
         <fieldset class="coop-c-form-choice" aria-describedby="radio-2-hint">
             <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
-            <p id="radio-2-hint" class="coop-form__hint coop-c-form-choice__hint">Select only one option</p>
+            <p id="radio-2-hint" class="coop-form__hint">Select only one option</p>
             <div class="coop-c-form-choice">
                 <input type="radio" name="radio-2" id="radio-2-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
                 <label class="coop-form__label coop-c-form-choice__label" for="radio-2-1">Free delivery</label>
@@ -88,7 +88,7 @@
     <div class="coop-form__row">
         <fieldset class="coop-c-form-choice" aria-describedby="checkbox-3-error">
             <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
-            <p id="checkbox-3-error" class="coop-form__error coop-c-form-choice__error">Select options owned by you</p>
+            <p id="checkbox-3-error" class="coop-form__error">Select options owned by you</p>
             <div class="coop-c-form-choice">
                 <input type="checkbox" name="checkbox-3" id="checkbox-3-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
                 <label for="checkbox-3-1" class="coop-form__label coop-c-form-choice__label">a business</label>
@@ -110,7 +110,7 @@
     <div class="coop-form__row">
         <fieldset class="coop-c-form-choice" aria-describedby="radio-3-error">
             <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
-            <p id="radio-3-error" class="coop-form__error coop-c-form-choice__error">Select type of delivery</p>
+            <p id="radio-3-error" class="coop-form__error">Select type of delivery</p>
             <div class="coop-c-form-choice">
                 <input type="radio" name="radio-3" id="radio-3-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
                 <label class="coop-form__label coop-c-form-choice__label" for="radio-3-1">Free delivery</label>
@@ -130,8 +130,8 @@
     <div class="coop-form__row">
         <fieldset class="coop-c-form-choice" aria-describedby="checkbox-4-hint checkbox-4-error">
             <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
-            <p id="checkbox-4-hint" class="coop-form__hint coop-c-form-choice__hint">Select all that apply</p>
-            <p id="checkbox-4-error" class="coop-form__error coop-c-form-choice__error">Select options owned by you</p>
+            <p id="checkbox-4-hint" class="coop-form__hint">Select all that apply</p>
+            <p id="checkbox-4-error" class="coop-form__error">Select options owned by you</p>
             <div class="coop-c-form-choice">
                 <input type="checkbox" name="checkbox-4" id="checkbox-4-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
                 <label for="checkbox-4-1" class="coop-form__label coop-c-form-choice__label">a business</label>
@@ -153,8 +153,8 @@
     <div class="coop-form__row">
         <fieldset class="coop-c-form-choice" aria-describedby="radio-4-hint radio-4-error">
             <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
-            <p id="radio-4-hint" class="coop-form__hint coop-c-form-choice__hint">Select only one option</p>
-            <p id="radio-4-error" class="coop-form__error coop-c-form-choice__error">Select type of delivery</p>
+            <p id="radio-4-hint" class="coop-form__hint">Select only one option</p>
+            <p id="radio-4-error" class="coop-form__error">Select type of delivery</p>
             <div class="coop-c-form-choice">
                 <input type="radio" name="radio-4" id="radio-4-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
                 <label class="coop-form__label coop-c-form-choice__label" for="radio-4-1">Free delivery</label>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-input/input.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-input/input.html
@@ -24,9 +24,9 @@
 <form class="coop-form">
     <h3>Input with error message</h3>
 
-    <div class="coop-form__row coop-c-form-error">
+    <div class="coop-form__row">
         <label for="full-name-3" class="coop-form__label">Full name</label>
-        <p id="full-name-3-error" class="coop-form__error coop-c-form-error__text">Enter your full name</p>
+        <p id="full-name-3-error" class="coop-form__error">Enter your full name</p>
         <input type="text" name="full-name-3" id="full-name-3" class="coop-form__field coop-form__input coop-form__invalid" aria-describedby="full-name-3-error">
     </div>
 </form>
@@ -35,10 +35,10 @@
 <form class="coop-form">
     <h3>Input with hint and error message</h3>
 
-    <div class="coop-form__row coop-c-form-error">
+    <div class="coop-form__row">
         <label for="full-name-4" class="coop-form__label">Full name</label>
         <p id="full-name-4-hint" class="coop-form__hint">This is an example hint</p>
-        <p id="full-name-4-error" class="coop-form__error coop-c-form-error__text">Enter your full name</p>
+        <p id="full-name-4-error" class="coop-form__error">Enter your full name</p>
         <input type="text" name="full-name-4" id="full-name-4" class="coop-form__field coop-form__input coop-form__invalid" aria-describedby="full-name-4-hint full-name-4-error">
     </div>
 </form>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-select/select.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-select/select.html
@@ -32,9 +32,9 @@
 <form class="coop-form">
     <h3>Select with error message</h3>
 
-    <div class="coop-form__row coop-c-form-error">
+    <div class="coop-form__row">
         <label class="coop-form__label" for="sort-by-3">Sort by:</label>
-        <p id="sort-by-3-error" class="coop-form__error coop-c-form-error__text">Select a sort by option</p>
+        <p id="sort-by-3-error" class="coop-form__error">Select a sort by option</p>
         <select id="sort-by-3" class="coop-form__field coop-form__select coop-form__invalid" aria-describedby="sort-by-3-error">
             <option value="relevancy">Relevancy</option>
             <option value="price-asc">Price: Low to high</option>
@@ -47,10 +47,10 @@
 <form class="coop-form">
     <h3>Select with hint and error message</h3>
 
-    <div class="coop-form__row coop-c-form-error">
+    <div class="coop-form__row">
         <label class="coop-form__label" for="sort-by-4">Sort by:</label>
         <p id="sort-by-4-hint" class="coop-form__hint">This is an example hint</p>
-        <p id="sort-by-4-error" class="coop-form__error coop-c-form-error__text">Select a sort by option</p>
+        <p id="sort-by-4-error" class="coop-form__error">Select a sort by option</p>
         <select id="sort-by-4" class="coop-form__field coop-form__select coop-form__invalid" aria-describedby="sort-by-4-hint sort-by-4-error">
             <option value="relevancy">Relevancy</option>
             <option value="price-asc">Price: Low to high</option>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-textarea/textarea.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-textarea/textarea.html
@@ -24,9 +24,9 @@
 <form class="coop-form">
     <h3>Textarea with hint</h3>
 
-    <div class="coop-form__row coop-c-form-error">
+    <div class="coop-form__row">
         <label for="feedback-3" class="coop-form__label">Tell us what you liked or what we can improve</label>
-        <p id="feedback-3-error" class="coop-form__error coop-c-form-error__text">Enter your feedback</p>
+        <p id="feedback-3-error" class="coop-form__error">Enter your feedback</p>
         <textarea id="feedback-3" cols="30" rows="4" class="coop-form__field coop-form__textarea coop-form__invalid" aria-describedby="feedback-3-error"></textarea>
     </div>
 </form>
@@ -35,10 +35,10 @@
 <form class="coop-form">
     <h3>Textarea with hint and error message</h3>
 
-    <div class="coop-form__row coop-c-form-error">
+    <div class="coop-form__row">
         <label for="feedback-4" class="coop-form__label">Tell us what you liked or what we can improve</label>
         <p id="feedback-4-hint" class="coop-form__hint">This is an example hint</p>
-        <p id="feedback-4-error" class="coop-form__error coop-c-form-error__text">Enter your feedback</p>
+        <p id="feedback-4-error" class="coop-form__error">Enter your feedback</p>
         <textarea id="feedback-4" cols="30" rows="4" class="coop-form__field coop-form__textarea coop-form__invalid" aria-describedby="feedback-4-hint feedback-4-error"></textarea>
     </div>
 </form>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-validation/validation.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-validation/validation.html
@@ -8,15 +8,15 @@
             <li><a class="coop-c-message__link" href="#client-email-address">enter an email address</a></li>
         </ul>
     </div>
-    <div class="coop-form__row coop-c-form-error">
+    <div class="coop-form__row">
         <label class="coop-form__label" for="client-name">Your full name</label>
-        <p id="client-name-error" class="coop-form__error coop-c-form-error__text">Enter your full name</p>
+        <p id="client-name-error" class="coop-form__error">Enter your full name</p>
         <input class="coop-form__field coop-form__input coop-form__invalid" type="text" value="" name="client[name]" id="client-name" aria-describedby="client-name-error">
     </div>
-    <div class="coop-form__row coop-c-form-error">
+    <div class="coop-form__row">
         <label class="coop-form__label" for="client-email-address">Your email address</label>
         <p id="client-email-address-hint" class="coop-form__hint">We’ll only use this to contact you about your will.</p>
-        <p id="client-email-address-error" class="coop-form__error coop-c-form-error__text">Enter an email address</p>
+        <p id="client-email-address-error" class="coop-form__error">Enter an email address</p>
         <input class="coop-form__field coop-form__input coop-form__invalid" type="email" value="" name="client[email_address]" id="client-email-address" aria-describedby="client-email-address-hint client-email-address-error">
     </div>
 </form>

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -371,7 +371,3 @@ label + .coop-form__error,
   background: var(--color-red-error-light);
   border: 1px solid var(--color-red-error);
 }
-
-.coop-c-form-error__text {
-  color: var(--color-red-error);
-}

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -284,15 +284,6 @@ label + .coop-form__error,
   touch-action: manipulation;
 }
 
-.coop-c-form-choice__hint,
-.coop-c-form-choice__error {
-  margin-bottom: var(--spacing-4);
-
-  @media (--mq-medium) {
-    margin-bottom: var(--spacing-8);
-  }
-}
-
 .coop-c-form-choice__input:focus + .coop-c-form-choice__label::before {
   outline-offset: 3px;
   outline: 2px solid var(--color-link--focus);


### PR DESCRIPTION
This PR removes duplicate CSS.

**.coop-c-form-error**
The class for form errors `.coop-c-form-error__text` is duplicated by `coop-form__error`

**.coop-c-form-choice**
The class for radio/checkbox errors `coop-c-form-choice__error` is duplicated by `coop-form__error`
The class for radio/checkbox hints `coop-c-form-choice__hint` is duplicated by `coop-form__hint`

I've removed them until we do the next refactor, without any visual changes:

![Checkboxes](https://user-images.githubusercontent.com/415517/91987821-6fe46280-ed26-11ea-8faa-ca5a1e2165d7.png)

It was making the HTML examples here unnecessarily wordy:
https://coop-design-system.herokuapp.com/pattern-library/foundations/checkboxes-and-radio-buttons.html