### PR TITLE
Align error summary box with notification styling

### DIFF
--- a/design-system/src/_includes/pattern-library/foundations/foundations-validation/validation.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-validation/validation.html
@@ -1,9 +1,9 @@
 
 <form class="coop-form">
     <div class="coop-c-message coop-c-message--error" aria-labelledby="error-message-heading" tabindex="-1" role="alert">
-        <h2 id="error-message-heading">There’s a problem</h2>
-        <p>Check the form. You must:</p>
-        <ul>
+        <h2 id="error-message-heading" class="coop-c-message__heading">There’s a problem</h2>
+        <p class="coop-c-message__message">Check the form. You must:</p>
+        <ul class="coop-c-message__list">
             <li><a class="coop-c-message__link" href="#client-name">enter your full name</a></li>
             <li><a class="coop-c-message__link" href="#client-email-address">enter an email address</a></li>
         </ul>

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -340,8 +340,8 @@ label + .coop-form__error,
 }
 
 .coop-c-message {
-  padding: var(--spacing-8) var(--spacing-16);
-  margin-bottom: var(--spacing-16);
+  padding: var(--spacing-16);
+  margin-bottom: var(--spacing-32);
 
   &:focus {
     outline-offset: 3px;
@@ -350,15 +350,24 @@ label + .coop-form__error,
 
   @media (--mq-medium) {
     padding: var(--spacing-16) var(--spacing-32);
-    margin-bottom: var(--spacing-32);
+    margin-bottom: calc(var(--spacing-32) * 1.25);
   }
 }
 
-.coop-c-message__link {
-  color: var(--color-red-error);
+.coop-c-message__heading,
+.coop-c-message__list {
+  margin-bottom: var(--spacing-4);
+
+  @media (--mq-medium) {
+    margin-bottom: var(--spacing-8);
+  }
 }
 
 .coop-c-message--error {
   background: var(--color-red-error-light);
-  border: 1px solid var(--color-red-error);
+  border-left: 4px solid var(--color-red-error);
+}
+
+.coop-c-message--error .coop-c-message__link {
+  color: var(--color-red-error);
 }


### PR DESCRIPTION
We've updated the new form styling here: https://github.com/coopdigital/coop-frontend/pull/151

So anything with a 1px stroke now looks out of date 😱 

Do we need to update the form validation error summary box?

### Before
![Before](https://user-images.githubusercontent.com/415517/92001518-ade98280-ed36-11ea-9ef5-eb7258575027.png)

### After
![After](https://user-images.githubusercontent.com/415517/92001533-b346cd00-ed36-11ea-9a04-9c471e7f2bcb.png)
