### PR TITLE
Add "Date input" page and examples to Design System

### DIFF
--- a/design-system/package-lock.json
+++ b/design-system/package-lock.json
@@ -21,6 +21,11 @@
       "resolved": "https://registry.npmjs.org/@coopdigital/component-card--product/-/component-card--product-2.1.11.tgz",
       "integrity": "sha512-GYvtaGbRNwq64oyZRvvW5fazzck7zpb3W3bKNqAJ8M5jsskyz5QQfFu0R9xanJTKSD8Hoe8BaSpPs1wnisivag=="
     },
+    "@coopdigital/component-date-input": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@coopdigital/component-date-input/-/component-date-input-1.0.4.tgz",
+      "integrity": "sha512-he0maTlE3Oa4cSUmPHmu6rMJXq+1HcIWVO9EyMtLKzTRo04YZdD8ZOURoAAhcXHR2qFPibjOE/ff7xBVhVS9Gw=="
+    },
     "@coopdigital/component-notification": {
       "version": "1.0.18",
       "resolved": "https://registry.npmjs.org/@coopdigital/component-notification/-/component-notification-1.0.18.tgz",
@@ -67,9 +72,9 @@
       "integrity": "sha512-jMRBAKacy48INGpiftNJdWovS7H+wEFiP0qalbo9DImgxAo99cv0NNhMQVVJIjoEkszFOKU1HBpNOD5hg9ph8Q=="
     },
     "@coopdigital/foundations-forms": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@coopdigital/foundations-forms/-/foundations-forms-4.0.3.tgz",
-      "integrity": "sha512-Snvqh8zpzZ7MUG0CzWNxPVslIFc3EJUf6r+zP+ow7JvDTnnBlxezTNoL0jlycFSwD2sR9p5wwqLQwpkZ7tw+Cg=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@coopdigital/foundations-forms/-/foundations-forms-4.0.4.tgz",
+      "integrity": "sha512-Q+A+uIDPq01WN4V6KzCS+iqzPy9TCSLNe6e04nVDrxLwrEXYfqvA/8hK9s/Hmz8GS7UU6Mx2FPgiOtOdkjn8mA=="
     },
     "@coopdigital/foundations-global": {
       "version": "3.1.11",

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@coopdigital/component-card": "^3.1.11",
     "@coopdigital/component-card--product": "^2.1.11",
+    "@coopdigital/component-date-input": "^1.0.4",
     "@coopdigital/component-notification": "^1.0.18",
     "@coopdigital/component-notification--alert": "^1.0.22",
     "@coopdigital/component-search": "^2.1.11",
@@ -24,7 +25,7 @@
     "@coopdigital/component-tags": "^3.1.11",
     "@coopdigital/foundations-buttons": "^2.1.12",
     "@coopdigital/foundations-colors": "^2.1.11",
-    "@coopdigital/foundations-forms": "^4.0.3",
+    "@coopdigital/foundations-forms": "^4.0.4",
     "@coopdigital/foundations-global": "^3.1.11",
     "@coopdigital/foundations-grid": "^2.0.6",
     "@coopdigital/foundations-layout": "^3.1.11",

--- a/design-system/src/_css/main.css
+++ b/design-system/src/_css/main.css
@@ -17,6 +17,7 @@
 @import "@coopdigital/component-search";
 @import "@coopdigital/component-card";
 @import "@coopdigital/component-card--product";
+@import "@coopdigital/component-date-input";
 @import "@coopdigital/component-skipnav";
 
 @import '@coopdigital/component-tags';

--- a/design-system/src/pattern-library/examples/components/date-input.html
+++ b/design-system/src/pattern-library/examples/components/date-input.html
@@ -1,0 +1,9 @@
+---
+layout: blank
+id: examples
+---
+<div class="coop-l-row">
+    <div class="coop-l-column coop-l-large-4 coop-l-medium-6 coop-l-small-12">
+        {% include pattern-library/components/component-date-input/src/date-input.html %}
+    </div>
+</div>

--- a/design-system/src/pattern-library/examples/index.html
+++ b/design-system/src/pattern-library/examples/index.html
@@ -1348,6 +1348,9 @@ id: examples
         {% include pattern-library/foundations/foundations-select/select.html %}
     </div>
     <div class="coop-u-margin-b-32">
+        {% include pattern-library/components/component-date-input/src/date-input.html %}
+    </div>
+    <div class="coop-u-margin-b-32">
         <h3>Buttons</h3>
         <button class="coop-btn coop-btn--primary">Primary button</button>
         <button class="coop-btn">Button</button>

--- a/design-system/src/pattern-library/foundations/bullet-list.html
+++ b/design-system/src/pattern-library/foundations/bullet-list.html
@@ -28,8 +28,8 @@ id: pattern-library
     <nav class="coop-l-container">
         <ul class="in-page-nav in-page-nav--horz">
             <li><a href="#example">Example</a></li>
-            <!-- <li><a href="#design-and-content">Design and content</a></li> -->
-            <!-- <li><a href="#accessibility">Accessibility</a></li> -->
+            <li><a href="#design-and-content">Design and content</a></li>
+            <li><a href="#variations">Related components</a></li>
             <li><a href="#suggest-a-change">Suggest a change</a></li>
         </ul>
     </nav>
@@ -76,10 +76,6 @@ id: pattern-library
                 <h2>Design and content</h2>
                 <p>{{ designPattern.design_and_content_documentation | markdownify }}</p>
             </section>
-            <!-- <section id="accessibility" class="coop-u-margin-resp-b-32-16 coop-u-padding-resp-b-32-16">
-                <h2>Accessibility</h2>
-                <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
-            </section> -->
             <section id="variations" class="coop-u-margin-resp-b-32-16">
                 <h2>Related components</h2>
                 <p>{{ designPattern.variations | markdownify }}</p>

--- a/design-system/src/pattern-library/foundations/buttons.html
+++ b/design-system/src/pattern-library/foundations/buttons.html
@@ -30,7 +30,6 @@ id: pattern-library
             <li><a href="#example">Example</a></li>
             <li><a href="#design-and-content">Design and content</a></li>
             <li><a href="#accessibility">Accessibility</a></li>
-            <li><a href="#suggest-a-change">Suggest a change</a></li>
         </ul>
     </nav>
 </div>

--- a/design-system/src/pattern-library/foundations/centring.html
+++ b/design-system/src/pattern-library/foundations/centring.html
@@ -28,9 +28,6 @@ id: pattern-library
     <nav class="coop-l-container">
         <ul class="in-page-nav in-page-nav--horz">
             <li><a href="#example">Example</a></li>
-            <!-- <li><a href="#design-and-content">Design and content</a></li> -->
-            <!-- <li><a href="#accessibility">Accessibility</a></li> -->
-            <li><a href="#suggest-a-change">Suggest a change</a></li>
         </ul>
     </nav>
 </div>
@@ -62,20 +59,6 @@ id: pattern-library
                     </ul>
                 </section>
             </div>
-        </div>
-    </div>
-</div>
-<div class="coop-l-container">
-    <div class="coop-l-grid">
-        <div class="coop-l-grid__item coop-l-grid__item--medium-7">
-            <!-- <section id="design-and-content" class="coop-u-margin-resp-b-32-16">
-                <h2>Design and content</h2>
-                <p>{{ designPattern.design_and_content_documentation | markdownify }}</p>
-            </section> -->
-            <!-- <section id="accessibility" class="coop-u-margin-resp-b-32-16">
-                <h2>Accessibility</h2>
-                <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
-            </section> -->
         </div>
     </div>
 </div>

--- a/design-system/src/pattern-library/foundations/checkboxes-and-radio-buttons.html
+++ b/design-system/src/pattern-library/foundations/checkboxes-and-radio-buttons.html
@@ -29,7 +29,6 @@ id: pattern-library
         <ul class="in-page-nav in-page-nav--horz">
             <li><a href="#example">Example</a></li>
             <li><a href="#design-and-content">Design and content</a></li>
-            <!-- <li><a href="#accessibility">Accessibility</a></li> -->
         </ul>
     </nav>
 </div>
@@ -75,10 +74,6 @@ id: pattern-library
                 <h2>Design and content</h2>
                 <p>{{ designPattern.design_and_content_documentation | markdownify }}</p>
             </section>
-            <!-- <section id="accessibility" class="coop-u-margin-resp-b-32-16">
-                <h2>Accessibility</h2>
-                <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
-            </section> -->
         </div>
     </div>
 </div>

--- a/design-system/src/pattern-library/foundations/collapsing-columns.html
+++ b/design-system/src/pattern-library/foundations/collapsing-columns.html
@@ -28,8 +28,6 @@ id: pattern-library
     <nav class="coop-l-container">
         <ul class="in-page-nav in-page-nav--horz">
             <li><a href="#example">Example</a></li>
-            <!-- <li><a href="#design-and-content">Design and content</a></li> -->
-            <!-- <li><a href="#accessibility">Accessibility</a></li> -->
         </ul>
     </nav>
 </div>

--- a/design-system/src/pattern-library/foundations/date-input.html
+++ b/design-system/src/pattern-library/foundations/date-input.html
@@ -1,0 +1,87 @@
+---
+layout: default
+body-page-class: dm-dark
+title: Date input
+id: pattern-library
+---
+<article>
+    <div class="coop-l-container">
+{% include breadcrumbs.html %}
+{% for designPattern in site.data.contentful.spaces.design-system-content.designPattern %}
+    {% if designPattern.title == 'Date input' %}
+    <header>
+        <div class="coop-l-grid">
+            <div class="coop-l-grid__item coop-l-grid__item--medium-7 intro-box">
+                <h1>{{ designPattern.title }}
+                    <span class="status status--{{ designPattern.status }}">
+                        <a href="/process.html" class="status__link">{{ designPattern.status }}</a>
+                    </span>
+                </h1>
+                <div class="highlight-banner">
+                    <p class="ds-intro">{{ designPattern.introduction | markdownify }}</p>
+                </div>
+            </div>
+        </div>
+    </header>
+</div>
+<div class="fixedsticky fixedsticky--horz">
+    <nav class="coop-l-container">
+        <ul class="in-page-nav in-page-nav--horz">
+            <li><a href="#example">Example</a></li>
+            <!-- <li><a href="#design-and-content">Design and content</a></li>
+            <li><a href="#accessibility">Accessibility</a></li> -->
+        </ul>
+    </nav>
+</div>
+<div class="coop-u-grey-light-bg coop-u-padding-resp-t-32-16 coop-u-padding-resp-b-32-16 coop-u-margin-resp-b-32-16">
+    <div class="coop-l-container">
+        <div class="coop-l-grid">
+            <div class="coop-l-grid__item">
+                <section id="example" class="coop-ds-example">
+                    <header class="ds-pen-example__header">
+                        <h2 class="Pen-panel-title pull-left">Example</h2>
+                    </header>
+                    <div id="TabContainer">
+                        <div class="accordion-wrapper">
+                            <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
+                            <div class="tabs-container__panel" id="Tab1">
+                                <div class="coop-l-grid">
+                                    <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
+                                        {% include pattern-library/components/component-date-input/src/date-input.html %}
+                                    </div>
+                                </div>
+                            </div>
+                            <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
+                            <div class="tabs-container__panel" id="Tab2">
+                                {% highlight html %}
+                                {% include pattern-library/components/component-date-input/src/date-input.html %}
+                                {% endhighlight %}
+                            </div>
+                        </div>
+                    </div>
+                    <ul class="coop-list-bare coop-list-inline dm-icon-list">
+                        <li><img src="/images/icons/github.svg" class="coop-c-icon__left" alt="" /><a href="{{ designPattern.github_url }}" class="coop-u-link-black">Get the code from Github</a></li>
+                        <li><img src="/images/icons/npm.svg" class="coop-c-icon__left coop-c-icon__left--npm" alt="" /><a href="{{ designPattern.npm_url }}" class="coop-u-link-black">Install the code from NPM</a></li>
+                    </ul>
+                </section>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="coop-l-container">
+    <div class="coop-l-grid">
+        <div class="coop-l-grid__item coop-l-grid__item--medium-7">
+            <section id="design-and-content" class="coop-u-margin-resp-b-32-16">
+                <h2>Design and content</h2>
+                <p>{{ designPattern.design_and_content_documentation | markdownify }}</p>
+            </section>
+            <section id="accessibility" class="coop-u-margin-resp-b-32-16">
+                <h2>Accessibility</h2>
+                <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
+            </section>
+        </div>
+    </div>
+</div>
+    {% endif %}
+{% endfor %}
+</article>

--- a/design-system/src/pattern-library/foundations/date-input.html
+++ b/design-system/src/pattern-library/foundations/date-input.html
@@ -28,8 +28,7 @@ id: pattern-library
     <nav class="coop-l-container">
         <ul class="in-page-nav in-page-nav--horz">
             <li><a href="#example">Example</a></li>
-            <!-- <li><a href="#design-and-content">Design and content</a></li>
-            <li><a href="#accessibility">Accessibility</a></li> -->
+            <li><a href="#design-and-content">Design and content</a></li>
         </ul>
     </nav>
 </div>
@@ -74,10 +73,6 @@ id: pattern-library
             <section id="design-and-content" class="coop-u-margin-resp-b-32-16">
                 <h2>Design and content</h2>
                 <p>{{ designPattern.design_and_content_documentation | markdownify }}</p>
-            </section>
-            <section id="accessibility" class="coop-u-margin-resp-b-32-16">
-                <h2>Accessibility</h2>
-                <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
             </section>
         </div>
     </div>

--- a/design-system/src/pattern-library/foundations/font.html
+++ b/design-system/src/pattern-library/foundations/font.html
@@ -29,7 +29,6 @@ id: pattern-library
             <ul class="in-page-nav in-page-nav--horz">
                 <li><a href="#example">Example</a></li>
                 <li><a href="#design-and-content">Design and content</a></li>
-                <!-- <li><a href="#accessibility">Accessibility</a></li> -->
             </ul>
         </nav>
     </div>
@@ -75,10 +74,6 @@ id: pattern-library
                     <h2>Design and content</h2>
                     <p>{{ designPattern.design_and_content_documentation | markdownify }}</p>
                 </section>
-                <!-- <section id="accessibility" class="coop-u-margin-resp-b-32-16">
-                    <h2>Accessibility</h2>
-                    <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
-                </section> -->
             </div>
         </div>
     </div>

--- a/design-system/src/pattern-library/foundations/input.html
+++ b/design-system/src/pattern-library/foundations/input.html
@@ -28,8 +28,6 @@ id: pattern-library
     <nav class="coop-l-container">
         <ul class="in-page-nav in-page-nav--horz">
             <li><a href="#example">Example</a></li>
-            <!-- <li><a href="#design-and-content">Design and content</a></li>
-            <li><a href="#accessibility">Accessibility</a></li> -->
         </ul>
     </nav>
 </div>
@@ -65,20 +63,6 @@ id: pattern-library
                     </ul>
                 </section>
             </div>
-        </div>
-    </div>
-</div>
-<div class="coop-l-container">
-    <div class="coop-l-grid">
-        <div class="coop-l-grid__item coop-l-grid__item--medium-7">
-            <!-- <section id="design-and-content" class="coop-u-margin-resp-b-32-16">
-                <h2>Design and content</h2>
-                <p>{{ designPattern.design_and_content_documentation | markdownify }}</p>
-            </section>
-            <section id="accessibility" class="coop-u-margin-resp-b-32-16">
-                <h2>Accessibility</h2>
-                <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
-            </section> -->
         </div>
     </div>
 </div>

--- a/design-system/src/pattern-library/foundations/numbered-list.html
+++ b/design-system/src/pattern-library/foundations/numbered-list.html
@@ -28,9 +28,7 @@ id: pattern-library
     <nav class="coop-l-container">
         <ul class="in-page-nav in-page-nav--horz">
             <li><a href="#example">Example</a></li>
-            <!-- <li><a href="#design-and-content">Design and content</a></li> -->
-            <!-- <li><a href="#accessibility">Accessibility</a></li> -->
-            <li><a href="#suggest-a-change">Suggest a change</a></li>
+            <li><a href="#variations">Related components</a></li>
         </ul>
     </nav>
 </div>
@@ -76,10 +74,6 @@ id: pattern-library
                 <h2>Design and content</h2>
                 <p>{{ designPattern.design_and_content_documentation | markdownify }}</p>
             </section>
-            <!-- <section id="accessibility" class="coop-u-margin-resp-b-32-16">
-                <h2>Accessibility</h2>
-                <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
-            </section> -->
             <section id="variations" class="coop-u-margin-resp-b-32-16">
                 <h2>Related components</h2>
                 <p>{{ designPattern.variations | markdownify }}</p>

--- a/design-system/src/pattern-library/foundations/quotations.html
+++ b/design-system/src/pattern-library/foundations/quotations.html
@@ -80,7 +80,7 @@ id: pattern-library
                 <h2>Accessibility</h2>
                 <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
             </section>
-            <section id="accessibility" class="coop-u-margin-resp-b-32-16">
+            <section id="variations" class="coop-u-margin-resp-b-32-16">
                 <h2>Variations</h2>
                 <p>{{ designPattern.variations | markdownify }}</p>
             </section>

--- a/design-system/src/pattern-library/foundations/tables.html
+++ b/design-system/src/pattern-library/foundations/tables.html
@@ -28,7 +28,6 @@ id: pattern-library
         <nav class="coop-l-container">
             <ul class="in-page-nav in-page-nav--horz">
                 <li><a href="#example">Example</a></li>
-                <!-- <li><a href="#design-and-content">Design and content</a></li> -->
                 <li><a href="#accessibility">Accessibility</a></li>
             </ul>
         </nav>
@@ -71,10 +70,6 @@ id: pattern-library
     <div class="coop-l-container">
         <div class="coop-l-grid">
             <div class="coop-l-grid__item coop-l-grid__item--medium-7">
-                <!-- <section id="design-and-content" class="coop-u-margin-resp-b-32-16">
-                    <h2>Design and content</h2>
-                    <p>{{ designPattern.design_and_content_documentation | markdownify }}</p>
-                </section> -->
                 <section id="accessibility" class="coop-u-margin-resp-b-32-16">
                     <h2>Accessibility</h2>
                     <p>{{ designPattern.accessibility_documentation | markdownify }}</p>

--- a/design-system/src/pattern-library/foundations/validation.html
+++ b/design-system/src/pattern-library/foundations/validation.html
@@ -28,8 +28,6 @@ id: pattern-library
         <nav class="coop-l-container">
             <ul class="in-page-nav in-page-nav--horz">
                 <li><a href="#example">Example</a></li>
-                <!-- <li><a href="#design-and-content">Design and content</a></li> -->
-                <!-- <li><a href="#accessibility">Accessibility</a></li> -->
             </ul>
         </nav>
     </div>
@@ -75,10 +73,6 @@ id: pattern-library
                     <h2>Design and content</h2>
                     <p>{{ designPattern.design_and_content_documentation | markdownify }}</p>
                 </section>
-                <!-- <section id="accessibility" class="coop-u-margin-resp-b-32-16">
-                    <h2>Accessibility</h2>
-                    <p>{{ designPattern.accessibility_documentation | markdownify }}</p>
-                </section> -->
             </div>
         </div>
     </div>

--- a/design-system/src/pattern-library/index.html
+++ b/design-system/src/pattern-library/index.html
@@ -216,6 +216,22 @@ title: Pattern library
                         </div>
                         <div class="coop-l-grid__item coop-l-grid__item--medium-6">
                             <div class="ds-c-signpost">
+                                <a class="ds-c-signpost__link" href="/pattern-library/foundations/date-input.html">
+                                    <div class="ds-c-signpost__content">
+                                        <h3 class="ds-c-signpost__title">
+                                            Date input
+                                        </h3>
+                                        <span class="ds-c-signpost__icon" aria-hidden="true">
+                                            <svg class="ds-c-signpost__icon__svg" viewBox="0 0 16 29">
+                                            <path d="M1.909 28.11a1.575 1.575 0 0 1-1.115-2.691L11.713 14.5.793 3.58a1.575 1.575 0 1 1 2.23-2.228l12.033 12.033a1.575 1.575 0 0 1 0 2.229L3.023 27.647c-.307.308-.71.463-1.114.463z"/>
+                                            </svg>
+                                        </span>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                        <div class="coop-l-grid__item coop-l-grid__item--medium-6">
+                            <div class="ds-c-signpost">
                                 <a class="ds-c-signpost__link" href="/pattern-library/foundations/textarea.html">
                                     <div class="ds-c-signpost__content">
                                         <h3 class="ds-c-signpost__title">


### PR DESCRIPTION
The **Date input** component from https://github.com/coopdigital/coop-frontend/pull/154 is now merged and published 🎉 

This PR pulls together the page added by @mchadwickweb and @MBLHarrison.

i.e. Can we add it to the Design System?

![Patterns](https://user-images.githubusercontent.com/415517/92116392-adf78a00-edeb-11ea-83e5-4c49e09de195.png)

Together with the new content page below:

![Page](https://user-images.githubusercontent.com/415517/92116398-b059e400-edeb-11ea-9794-f0c702a168ad.png)
