### PR TITLE
Allow "Date input" to squish a little

### DIFF
--- a/packages/component-date-input/src/date-input.html
+++ b/packages/component-date-input/src/date-input.html
@@ -53,11 +53,11 @@
 <form class="coop-form">
   <h3>Date input with error message</h3>
 
-  <div class="coop-form__row coop-c-form-error">
+  <div class="coop-form__row">
     <fieldset aria-describedby="dob-2-hint dob-2-error">
       <legend class="coop-form__label">What is your date of birth?</legend>
       <p id="dob-2-hint" class="coop-form__hint">For example 21 12 2020</p>
-      <p id="dob-2-error" class="coop-form__error coop-c-form-error__text">The month you entered is invalid</p>
+      <p id="dob-2-error" class="coop-form__error">The month you entered is invalid</p>
       <div class="coop-form__column">
         <label class="coop-form__label" for="dob-2-day">Day</label>
         <input

--- a/packages/component-date-input/src/date-input.html
+++ b/packages/component-date-input/src/date-input.html
@@ -6,44 +6,46 @@
     <fieldset aria-describedby="dob-1-hint">
       <legend class="coop-form__label">What is your date of birth?</legend>
       <p id="dob-1-hint" class="coop-form__hint">For example 21 12 2020</p>
-      <div class="coop-form__column">
-        <label class="coop-form__label" for="dob-1-day">Day</label>
-        <input
-          id="dob-1-day"
-          type="text"
-          pattern="[0-9]*"
-          inputmode="numeric"
-          maxlength="2"
-          minlength="2"
-          autocomplete="bday-day"
-          class="coop-form__field coop-form__input coop-form__input--width-2"
-        >
-      </div>
-      <div class="coop-form__column">
-        <label class="coop-form__label" for="dob-1-month">Month</label>
-        <input
-          id="dob-1-month"
-          type="text"
-          pattern="[0-9]*"
-          inputmode="numeric"
-          maxlength="2"
-          minlength="2"
-          autocomplete="bday-month"
-          class="coop-form__field coop-form__input coop-form__input--width-2"
-        >
-      </div>
-      <div class="coop-form__column">
-        <label class="coop-form__label" for="dob-1-year">Year</label>
-        <input
-          id="dob-1-year"
-          type="text"
-          pattern="[0-9]*"
-          inputmode="numeric"
-          maxlength="4"
-          minlength="4"
-          autocomplete="bday-year"
-          class="coop-form__field coop-form__input coop-form__input--width-4"
-        >
+      <div class="coop-form__columns">
+        <div class="coop-form__column">
+          <label class="coop-form__label" for="dob-1-day">Day</label>
+          <input
+            id="dob-1-day"
+            type="text"
+            pattern="[0-9]*"
+            inputmode="numeric"
+            maxlength="2"
+            minlength="2"
+            autocomplete="bday-day"
+            class="coop-form__field coop-form__input coop-form__input--width-2"
+          >
+        </div>
+        <div class="coop-form__column">
+          <label class="coop-form__label" for="dob-1-month">Month</label>
+          <input
+            id="dob-1-month"
+            type="text"
+            pattern="[0-9]*"
+            inputmode="numeric"
+            maxlength="2"
+            minlength="2"
+            autocomplete="bday-month"
+            class="coop-form__field coop-form__input coop-form__input--width-2"
+          >
+        </div>
+        <div class="coop-form__column">
+          <label class="coop-form__label" for="dob-1-year">Year</label>
+          <input
+            id="dob-1-year"
+            type="text"
+            pattern="[0-9]*"
+            inputmode="numeric"
+            maxlength="4"
+            minlength="4"
+            autocomplete="bday-year"
+            class="coop-form__field coop-form__input coop-form__input--width-4"
+          >
+        </div>
       </div>
     </fieldset>
   </div>
@@ -58,44 +60,47 @@
       <legend class="coop-form__label">What is your date of birth?</legend>
       <p id="dob-2-hint" class="coop-form__hint">For example 21 12 2020</p>
       <p id="dob-2-error" class="coop-form__error">The month you entered is invalid</p>
-      <div class="coop-form__column">
-        <label class="coop-form__label" for="dob-2-day">Day</label>
-        <input
-          id="dob-2-day"
-          type="text"
-          pattern="[0-9]*"
-          inputmode="numeric"
-          maxlength="2"
-          minlength="2"
-          autocomplete="bday-day"
-          class="coop-form__field coop-form__input coop-form__input--width-2 coop-form__invalid"
-        >
-      </div>
-      <div class="coop-form__column">
-        <label class="coop-form__label" for="dob-2-month">Month</label>
-        <input
-          id="dob-2-month"
-          type="text"
-          pattern="[0-9]*"
-          inputmode="numeric"
-          maxlength="2"
-          minlength="2"
-          autocomplete="bday-month"
-          class="coop-form__field coop-form__input coop-form__input--width-2 coop-form__invalid"
-        >
-      </div>
-      <div class="coop-form__column">
-        <label class="coop-form__label" for="dob-2-year">Year</label>
-        <input
-          id="dob-2-year"
-          type="text"
-          pattern="[0-9]*"
-          inputmode="numeric"
-          maxlength="4"
-          minlength="4"
-          autocomplete="bday-year"
-          class="coop-form__field coop-form__input coop-form__input--width-4 coop-form__invalid"
-        >
+
+      <div class="coop-form__columns">
+        <div class="coop-form__column">
+          <label class="coop-form__label" for="dob-2-day">Day</label>
+          <input
+            id="dob-2-day"
+            type="text"
+            pattern="[0-9]*"
+            inputmode="numeric"
+            maxlength="2"
+            minlength="2"
+            autocomplete="bday-day"
+            class="coop-form__field coop-form__input coop-form__input--width-2 coop-form__invalid"
+          >
+        </div>
+        <div class="coop-form__column">
+          <label class="coop-form__label" for="dob-2-month">Month</label>
+          <input
+            id="dob-2-month"
+            type="text"
+            pattern="[0-9]*"
+            inputmode="numeric"
+            maxlength="2"
+            minlength="2"
+            autocomplete="bday-month"
+            class="coop-form__field coop-form__input coop-form__input--width-2 coop-form__invalid"
+          >
+        </div>
+        <div class="coop-form__column">
+          <label class="coop-form__label" for="dob-2-year">Year</label>
+          <input
+            id="dob-2-year"
+            type="text"
+            pattern="[0-9]*"
+            inputmode="numeric"
+            maxlength="4"
+            minlength="4"
+            autocomplete="bday-year"
+            class="coop-form__field coop-form__input coop-form__input--width-4 coop-form__invalid"
+          >
+        </div>
       </div>
     </fieldset>
   </div>

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -20,13 +20,20 @@
   }
 }
 
+.coop-form__columns {
+  display: flex;
+  white-space: nowrap;
+  /* removes whitespace caused by inline-block */
+  font-size: 0;
+}
+
 .coop-form__column {
   display: inline-block;
   width: auto;
 }
 
 .coop-form__column + .coop-form__column {
-  margin-left: var(--spacing-8);
+  margin-left: var(--spacing-16);
 }
 
 label,


### PR DESCRIPTION
At really small sizes (320px viewport, e.g. 1st generation iPhone SE) the **Date Input** component works great…

We have `288px` available width.
The component takes up `271px`.

But, when displayed in the Design System tabs, space is a little more constrained.

We're going to need a bit of squish…

![Date input squish](https://user-images.githubusercontent.com/415517/92124321-8c9b9b80-edf5-11ea-9907-4d7a0130fb38.gif)
