### PR TITLE
Increase “Example” tab space on mobile

### DIFF
--- a/design-system/src/_css/design-system/code.css
+++ b/design-system/src/_css/design-system/code.css
@@ -8,6 +8,7 @@ pre[class*="language-"] {
 
 code[class*="language-"],
 pre[class*="language-"] {
+    margin: 0;
     -moz-tab-size: 2;
     -o-tab-size: 2;
     tab-size: 2;
@@ -28,7 +29,7 @@ pre[class*="language-"],
     background: #2a2a2a;
 }
 pre[class*="language-"] {
-    padding: 16px;
+    padding: 20px;
     overflow: auto;
 }
 

--- a/design-system/src/_css/design-system/pattern-example.css
+++ b/design-system/src/_css/design-system/pattern-example.css
@@ -12,8 +12,11 @@
 }
 
 .tabs-container__panel {
-    padding: 20px;
     background: var(--color-white);
+}
+
+.tabs-container__panel--preview {
+  padding: 20px;
 }
 
 .coop-ds-example {

--- a/design-system/src/_css/design-system/pattern-example.css
+++ b/design-system/src/_css/design-system/pattern-example.css
@@ -61,7 +61,7 @@
         display:block
     }
 }
-  
+
 @media (max-width: 750px) {
     .tabs-navigation,
     .tabs-init .tabs-container__panel,
@@ -105,21 +105,20 @@
       background: var(--color-white);
     }
 
+    .tabs-container__title:active,
+    .tabs-container__title:focus {
+        outline: 2px solid var(--color-link--focus);
+        outline-offset: 3px;
+    }
+
     .tabs-container__panel[aria-hidden="false"] {
       display: block;
-      margin: 16px 16px 32px 16px;
+      margin: 16px 0 32px;
       background: var(--color-white);
     }
 
     .tabs-container__title[aria-selected="true"] {
       background: var(--color-white);
-    }
-
-    .tabs-container__title[aria-selected="true"]:active,
-    .tabs-container__title[aria-selected="true"]:focus {
-        outline: 2px dotted #eec300;
-        outline: 2px dotted var(--color-link--focus);
-        outline-offset: 3px;
     }
 
     .tabs-container__panel.accordion--closed {

--- a/design-system/src/pattern-library/components/calls-to-action/membership.html
+++ b/design-system/src/pattern-library/components/calls-to-action/membership.html
@@ -43,7 +43,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item">
                                             {% include pattern-library/components/shared-component--membership/dist/membership.html %}
@@ -56,7 +56,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/shared-component--membership/dist/membership.html %}
                                     {% include pattern-library/components/shared-component--membership/dist/membership-signedin.html %}

--- a/design-system/src/pattern-library/components/calls-to-action/offers.html
+++ b/design-system/src/pattern-library/components/calls-to-action/offers.html
@@ -43,7 +43,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item">
                                             {% include pattern-library/components/shared-component--offers/dist/offers.html %}
@@ -51,7 +51,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/shared-component--offers/dist/offers.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/components/cards/editorial-card.html
+++ b/design-system/src/pattern-library/components/cards/editorial-card.html
@@ -44,7 +44,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--large-4 coop-l-grid__item--medium-6">
                                             {% include pattern-library/components/shared-component--editorialcard/dist/editorialCard.html %}
@@ -55,7 +55,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/shared-component--editorialcard/dist/editorialCard.html %}
                                     {% include pattern-library/components/shared-component--editorialcard/dist/editorialCard-horizontal.html %}

--- a/design-system/src/pattern-library/components/cards/feature-card.html
+++ b/design-system/src/pattern-library/components/cards/feature-card.html
@@ -43,7 +43,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--large-4 coop-l-grid__item--medium-6">
                                             {% include pattern-library/components/shared-component--featurecard/dist/featureCard.html %}
@@ -56,7 +56,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/shared-component--featurecard/dist/featureCard.html %}
                                     {% include pattern-library/components/shared-component--featurecard/dist/featureCard--horizontal.html %}

--- a/design-system/src/pattern-library/components/cards/product-card.html
+++ b/design-system/src/pattern-library/components/cards/product-card.html
@@ -45,7 +45,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--large-3 coop-l-grid__item--medium-6">
                                             {% include pattern-library/components/component-card--product/src/card--product.html %}
@@ -53,7 +53,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                         {% include pattern-library/components/component-card--product/src/card--product.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/components/forms/search.html
+++ b/design-system/src/pattern-library/components/forms/search.html
@@ -44,7 +44,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                             {% include pattern-library/components/component-search/src/component.html %}
@@ -52,7 +52,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/component-search/src/component.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/components/heroes/hero.html
+++ b/design-system/src/pattern-library/components/heroes/hero.html
@@ -43,7 +43,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item">
                                             {% include pattern-library/components/shared-component--hero/dist/hero.html %}
@@ -52,7 +52,7 @@ id: pattern-library
 
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/shared-component--hero/dist/hero.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/components/navigation/signpost.html
+++ b/design-system/src/pattern-library/components/navigation/signpost.html
@@ -44,7 +44,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--medium-6 coop-l-grid__item--large-3">
                                             {% include pattern-library/components/shared-component--signpost/dist/signpost.html %}
@@ -52,7 +52,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/shared-component--signpost/dist/signpost.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/components/navigation/skip-navigation.html
+++ b/design-system/src/pattern-library/components/navigation/skip-navigation.html
@@ -44,7 +44,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--large-4 coop-l-grid__item--medium-6">
                                             {% include pattern-library/components/component-skipnav/src/skipnav.html %}
@@ -52,7 +52,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/component-skipnav/src/skipnav.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/components/navigation/tags-flags.html
+++ b/design-system/src/pattern-library/components/navigation/tags-flags.html
@@ -45,7 +45,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item">
                                             {% include pattern-library/components/component-tags/src/tags-flags.html %}
@@ -53,7 +53,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/component-tags/src/tags-flags.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/components/navigation/tags.html
+++ b/design-system/src/pattern-library/components/navigation/tags.html
@@ -45,7 +45,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--medium-6 coop-l-grid__item--large-4">
                                             {% include pattern-library/components/component-tags/src/tags.html %}
@@ -53,7 +53,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/component-tags/src/tags.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/components/notifications/alert-notification.html
+++ b/design-system/src/pattern-library/components/notifications/alert-notification.html
@@ -45,7 +45,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item">
                                             {% include pattern-library/components/component-notification--alert/src/notification--alert.html %}
@@ -53,7 +53,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/component-notification--alert/src/notification--alert.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/components/notifications/information-notification.html
+++ b/design-system/src/pattern-library/components/notifications/information-notification.html
@@ -45,7 +45,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item">
                                             {% include pattern-library/components/component-notification/src/notification.html %}
@@ -53,7 +53,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/component-notification/src/notification.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/components/supporting-information/squircles.html
+++ b/design-system/src/pattern-library/components/supporting-information/squircles.html
@@ -44,11 +44,11 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     {% include pattern-library/components/component-squircles/src/squircles.html %}
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/components/component-squircles/src/squircles.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/bullet-list.html
+++ b/design-system/src/pattern-library/foundations/bullet-list.html
@@ -45,7 +45,7 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 <div class="coop-l-grid">
                                     <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                         {% include pattern-library/foundations/foundations-bullet-list/bullet-list.html %}
@@ -53,7 +53,7 @@ id: pattern-library
                                 </div>
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-bullet-list/bullet-list.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/buttons.html
+++ b/design-system/src/pattern-library/foundations/buttons.html
@@ -44,7 +44,7 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 <div class="coop-l-grid">
                                     <div class="coop-l-grid__item coop-l-grid__item--medium-12 coop-l-grid__item--large-8">
                                         {% include pattern-library/foundations/foundations-buttons/buttons.html %}
@@ -52,7 +52,7 @@ id: pattern-library
                                 </div>
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-buttons/buttons.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/centring.html
+++ b/design-system/src/pattern-library/foundations/centring.html
@@ -42,11 +42,11 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 {% include pattern-library/foundations/foundations-centring/centring.html %}
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-centring/centring.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/checkboxes-and-radio-buttons.html
+++ b/design-system/src/pattern-library/foundations/checkboxes-and-radio-buttons.html
@@ -43,7 +43,7 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 <div class="coop-l-grid">
                                     <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                         {% include pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html %}
@@ -51,7 +51,7 @@ id: pattern-library
                                 </div>
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/collapsing-columns.html
+++ b/design-system/src/pattern-library/foundations/collapsing-columns.html
@@ -42,11 +42,11 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 {% include pattern-library/foundations/foundations-collapse/collapse.html %}
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-collapse/collapse.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/date-input.html
+++ b/design-system/src/pattern-library/foundations/date-input.html
@@ -43,7 +43,7 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 <div class="coop-l-grid">
                                     <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                         {% include pattern-library/components/component-date-input/src/date-input.html %}
@@ -51,7 +51,7 @@ id: pattern-library
                                 </div>
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/components/component-date-input/src/date-input.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/font.html
+++ b/design-system/src/pattern-library/foundations/font.html
@@ -43,7 +43,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                             {% include pattern-library/foundations/foundations-typography/typography.html %}
@@ -51,7 +51,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/foundations/foundations-typography/typography.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/input.html
+++ b/design-system/src/pattern-library/foundations/input.html
@@ -42,7 +42,7 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 <div class="coop-l-grid">
                                     <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                         {% include pattern-library/foundations/foundations-input/input.html %}
@@ -50,7 +50,7 @@ id: pattern-library
                                 </div>
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-input/input.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/links.html
+++ b/design-system/src/pattern-library/foundations/links.html
@@ -44,7 +44,7 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 <div class="coop-l-grid">
                                     <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                         {% include pattern-library/foundations/foundations-links/links.html %}
@@ -52,7 +52,7 @@ id: pattern-library
                                 </div>
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-links/links.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/logo.html
+++ b/design-system/src/pattern-library/foundations/logo.html
@@ -44,7 +44,7 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 <div class="coop-l-grid">
                                     <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                         {% include pattern-library/foundations/foundations-logo/logo.html %}
@@ -52,7 +52,7 @@ id: pattern-library
                                 </div>
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-logo/logo.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/numbered-list.html
+++ b/design-system/src/pattern-library/foundations/numbered-list.html
@@ -43,7 +43,7 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 <div class="coop-l-grid">
                                     <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                         {% include pattern-library/foundations/foundations-numbered-list/numbered-list.html %}
@@ -51,7 +51,7 @@ id: pattern-library
                                 </div>
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-numbered-list/numbered-list.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/offset-columns.html
+++ b/design-system/src/pattern-library/foundations/offset-columns.html
@@ -42,11 +42,11 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 {% include pattern-library/foundations/foundations-offset/offset.html %}
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-offset/offset.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/page-layout.html
+++ b/design-system/src/pattern-library/foundations/page-layout.html
@@ -43,11 +43,11 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 {% include pattern-library/foundations/foundations-page-layout/page-layout.html %}
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-page-layout/page-layout.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/quotations.html
+++ b/design-system/src/pattern-library/foundations/quotations.html
@@ -45,7 +45,7 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 <div class="coop-l-grid">
                                     <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                         {% include pattern-library/foundations/foundations-quotations/quotations.html %}
@@ -53,7 +53,7 @@ id: pattern-library
                                 </div>
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-quotations/quotations.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/responsive-tables.html
+++ b/design-system/src/pattern-library/foundations/responsive-tables.html
@@ -43,7 +43,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                             {% include pattern-library/foundations/foundations-responsive-tables/responsive-tables.html %}
@@ -51,7 +51,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/foundations/foundations-responsive-tables/responsive-tables.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/reverse-columns-order.html
+++ b/design-system/src/pattern-library/foundations/reverse-columns-order.html
@@ -42,7 +42,7 @@ id: pattern-library
                     <div id="TabContainer">
                         <div class="accordion-wrapper">
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                            <div class="tabs-container__panel" id="Tab1">
+                            <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                 <div class="coop-l-grid">
                                     <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                         {% include pattern-library/foundations/foundations-reverse-order/reverse-order.html %}
@@ -50,7 +50,7 @@ id: pattern-library
                                 </div>
                             </div>
                             <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                            <div class="tabs-container__panel" id="Tab2">
+                            <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                 {% highlight html %}
                                 {% include pattern-library/foundations/foundations-reverse-order/reverse-order.html %}
                                 {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/select.html
+++ b/design-system/src/pattern-library/foundations/select.html
@@ -44,7 +44,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                             {% include pattern-library/foundations/foundations-select/select.html %}
@@ -52,7 +52,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/foundations/foundations-select/select.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/submit.html
+++ b/design-system/src/pattern-library/foundations/submit.html
@@ -44,7 +44,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                             {% include pattern-library/foundations/foundations-submit/submit.html %}
@@ -52,7 +52,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/foundations/foundations-submit/submit.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/tables.html
+++ b/design-system/src/pattern-library/foundations/tables.html
@@ -43,7 +43,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                             {% include pattern-library/foundations/foundations-tables/tables.html %}
@@ -51,7 +51,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/foundations/foundations-tables/tables.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/textarea.html
+++ b/design-system/src/pattern-library/foundations/textarea.html
@@ -43,7 +43,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--medium-8 coop-l-grid__item--large-6">
                                             {% include pattern-library/foundations/foundations-textarea/textarea.html %}
@@ -51,7 +51,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/foundations/foundations-textarea/textarea.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/typographic-scale.html
+++ b/design-system/src/pattern-library/foundations/typographic-scale.html
@@ -43,11 +43,11 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     {% include pattern-library/foundations/foundations-typographic-scale/typographic-scale.html %}
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/foundations/foundations-typographic-scale/typographic-scale.html %}
                                     {% endhighlight %}

--- a/design-system/src/pattern-library/foundations/validation.html
+++ b/design-system/src/pattern-library/foundations/validation.html
@@ -42,7 +42,7 @@ id: pattern-library
                         <div id="TabContainer">
                             <div class="accordion-wrapper">
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab1">Example</h3>
-                                <div class="tabs-container__panel" id="Tab1">
+                                <div class="tabs-container__panel tabs-container__panel--preview" id="Tab1">
                                     <div class="coop-l-grid">
                                         <div class="coop-l-grid__item coop-l-grid__item--large-6 coop-l-grid__item--medium-8">
                                             {% include pattern-library/foundations/foundations-validation/validation.html %}
@@ -50,7 +50,7 @@ id: pattern-library
                                     </div>
                                 </div>
                                 <h3 class="tabs-container__title" id="TabPanelTitle-Tab2">HTML</h3>
-                                <div class="tabs-container__panel" id="Tab2">
+                                <div class="tabs-container__panel tabs-container__panel--code" id="Tab2">
                                     {% highlight html %}
                                     {% include pattern-library/foundations/foundations-validation/validation.html %}
                                     {% endhighlight %}


### PR DESCRIPTION
The Design System component "Example" preview tab needs a bit more room on mobile.

Goes hand in hand with https://github.com/coopdigital/coop-frontend/pull/157

### Before

![Before](https://user-images.githubusercontent.com/415517/92126771-7ba05980-edf8-11ea-9c8a-ba94bf8c1458.png)

### After

![After](https://user-images.githubusercontent.com/415517/92126775-7e02b380-edf8-11ea-9e92-8172d2979f00.png)
