### PR TITLE
Fix typo on “Textarea with error message” example

### DIFF
--- a/design-system/src/_includes/pattern-library/foundations/foundations-textarea/textarea.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-textarea/textarea.html
@@ -22,7 +22,7 @@
 
 <!-- Textarea with error message -->
 <form class="coop-form">
-    <h3>Textarea with hint</h3>
+    <h3>Textarea with error message</h3>
 
     <div class="coop-form__row">
         <label for="feedback-3" class="coop-form__label">Tell us what you liked or what we can improve</label>


### PR DESCRIPTION
We've accidentally got two "with hint" Textarea examples when it should be "with error message".

![Typo](https://user-images.githubusercontent.com/415517/92376136-05526e80-f0fa-11ea-9140-bbee41f39ff4.png)
