### PR TITLE
Add "full width" and "loading" buttons

### DIFF
--- a/design-system/src/_includes/pattern-library/foundations/foundations-buttons/buttons.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-buttons/buttons.html
@@ -1,19 +1,46 @@
 
-<div class="coop-u-padding-resp-16-8 coop-u-margin-b-16">
-    <button class="coop-btn coop-btn--primary">Primary button</button>
-</div>
-<div class="coop-u-padding-resp-16-8 coop-u-margin-b-16">
-    <button class="coop-btn">Button</button>
-</div>
-<div class="coop-u-padding-resp-16-8 coop-u-margin-b-16">
+<form class="coop-form">
+  <h3>Primary button</h3>
+
+  <div class="coop-form__row">
+    <button class="coop-btn coop-btn--primary">Join Co-op for £1</button>
+  </div>
+</form>
+
+<form class="coop-form">
+  <h3>Secondary button</h3>
+
+  <div class="coop-form__row">
+    <button class="coop-btn">Find this product</button>
+  </div>
+</form>
+
+<form class="coop-form">
+  <h3>Grey button</h3>
+
+  <div class="coop-form__row">
     <button class="coop-btn coop-btn--grey">Button</button>
-</div>
-<div class="coop-u-padding-resp-16-8 coop-u-margin-b-32 coop-u-magenta-dark-3-bg">
-    <button class="coop-btn coop-btn--white">Button</button>
-</div>
-<div class="coop-u-padding-resp-16-8 coop-u-margin-b-8">
+  </div>
+</form>
+
+<form class="coop-form">
+  <h3>White button</h3>
+
+  <div class="coop-form__row">
+    <div class="coop-form__column coop-u-padding-resp-32-16 coop-u-magenta-dark-3-bg">
+      <button class="coop-btn coop-btn--white">Button</button>
+    </div>
+  </div>
+</form>
+
+<form class="coop-form">
+  <h3>Small button</h3>
+
+  <div class="coop-form__row">
     <button class="coop-btn coop-btn--small">Button small</button>
-</div>
-<div class="coop-u-padding-resp-16-8 coop-u-margin-b-8">
-  <button class="coop-t-link">Link button</button>
-</div>
+  </div>
+
+  <div class="coop-form__row">
+    <button class="coop-btn coop-btn--small coop-btn--grey">Button small</button>
+  </div>
+</form>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-buttons/buttons.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-buttons/buttons.html
@@ -52,3 +52,23 @@
     <button class="coop-btn coop-btn--full-width coop-btn--primary">Button</button>
   </div>
 </form>
+
+<form class="coop-form">
+  <h3>Loading spinner</h3>
+
+  <div class="coop-form__row">
+    <button class="coop-btn coop-btn--loading coop-btn--primary">Button</button>
+  </div>
+
+  <div class="coop-form__row">
+    <button class="coop-btn coop-btn--loading coop-btn--small coop-btn--primary">Button</button>
+  </div>
+</form>
+
+<form class="coop-form">
+  <h3>Link button</h3>
+
+  <div class="coop-form__row">
+    <button class="coop-t-link">Sign out</button>
+  </div>
+</form>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-buttons/buttons.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-buttons/buttons.html
@@ -44,3 +44,11 @@
     <button class="coop-btn coop-btn--small coop-btn--grey">Button small</button>
   </div>
 </form>
+
+<form class="coop-form">
+  <h3>Full width</h3>
+
+  <div class="coop-form__row">
+    <button class="coop-btn coop-btn--full-width coop-btn--primary">Button</button>
+  </div>
+</form>

--- a/design-system/src/_includes/pattern-library/foundations/foundations-submit/submit.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-submit/submit.html
@@ -1,2 +1,7 @@
+<form class="coop-form">
+  <h3>Primary submit button</h3>
 
-<button type="submit" class="coop-btn coop-btn--primary">Continue to booking</button>
+  <div class="coop-form__row">
+    <button type="submit" class="coop-btn coop-btn--primary">Continue to booking</button>
+  </div>
+</form>

--- a/packages/foundations-buttons/src/buttons.pcss
+++ b/packages/foundations-buttons/src/buttons.pcss
@@ -51,6 +51,10 @@
   outline: 0;
 }
 
+.coop-btn--full-width {
+  width: 100%;
+}
+
 .coop-btn--primary {
   background: var(--color-button-green-primary);
   color: var(--color-white);

--- a/packages/foundations-buttons/src/buttons.pcss
+++ b/packages/foundations-buttons/src/buttons.pcss
@@ -2,6 +2,16 @@
 
 @import "@coopdigital/foundations-vars";
 
+@keyframes coop-btn-spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 .coop-btn {
   display: inline-block;
   display: inline-flex;
@@ -113,5 +123,72 @@
 
   @media (--mq-medium) {
     height: 3.125rem; /* 50px / 16 */
+  }
+}
+
+/* Button (variable) with reserved space for spinner */
+.coop-btn--loading {
+  position: relative;
+  padding-right: calc((var(--spacing-16) * 1.25) + 38px);
+
+  @media (--mq-medium) {
+    padding-right: calc((var(--spacing-32) * 1.25) + 38px);
+  }
+}
+
+/* Button (small) with reserved space for spinner */
+.coop-btn--loading.coop-btn--small {
+  padding-right: calc((var(--spacing-16) * 1.25) + 38px);
+
+  @media (--mq-medium) {
+    padding-right: calc((var(--spacing-16) * 1.25) + 38px);
+  }
+}
+
+/* Button (full width) with reserved space for spinner */
+.coop-btn--loading.coop-btn--full-width {
+  padding-left: calc((var(--spacing-16) * 1.25) + 20px);
+  padding-right: calc((var(--spacing-16) * 1.25) + 20px);
+
+  @media (--mq-medium) {
+    padding-left: calc((var(--spacing-32) * 1.25) + 20px);
+    padding-right: calc((var(--spacing-32) * 1.25) + 20px);
+  }
+}
+
+/* Loading spinner */
+.coop-btn--loading:after {
+  position: absolute;
+  top: 1rem;
+  right: 20px;
+  content: "";
+  animation: coop-btn-spinner 1250ms infinite linear;
+  border: 2px solid;
+  border-right-color: transparent !important;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  transition: color 0s;
+
+  @media (--mq-medium) {
+    top: 1.25rem;
+    right: 40px;
+  }
+}
+
+/* Loading spinner (small button) */
+.coop-btn--loading.coop-btn--small:after {
+  top: 0.75rem;
+
+  @media (--mq-medium) {
+    top: 0.9375rem;
+    right: 20px;
+  }
+}
+
+/* Loading spinner (small button, full width ) */
+.coop-btn--loading.coop-btn--full-width.coop-btn--small:after {
+  @media (--mq-medium) {
+    right: 40px;
   }
 }


### PR DESCRIPTION
This PR includes two new button modifiers:

**1. Full width buttons**
`.coop-btn--full-width`

**2. Loading spinner buttons**
`.coop-btn--loading`

They work in combination with all other buttons (default, grey, white, small).

![Spinners](https://user-images.githubusercontent.com/415517/92384948-e6a7a400-f108-11ea-9299-7a74690ca393.gif)

(Ignore the "jump" as the GIF restarts, it's super-smooth in real life.)

I've also added supporting `<form class="coop-form">` and `<div class="coop-form__row">` wrapping markup to the button examples, so it's easier to see how they'd work in context:

![Button examples](https://user-images.githubusercontent.com/415517/92385155-47cf7780-f109-11ea-8907-eacca16d70c8.png)
