### PR TITLE
Support layout units of 12px, 24px, 48px

### DIFF
--- a/packages/foundations-layout/src/layout.pcss
+++ b/packages/foundations-layout/src/layout.pcss
@@ -146,6 +146,39 @@
   }
 }
 
+.coop-u-margin-24 {
+  margin: var(--spacing-24);
+}
+
+.coop-u-margin-24-12 {
+  margin: var(--spacing-12);
+  @media (--mq-medium) {
+    margin: var(--spacing-24);
+  }
+}
+
+.coop-u-margin-t-24 {
+  margin-top: var(--spacing-24);
+}
+
+.coop-u-margin-resp-t-24-12 {
+  margin-top: var(--spacing-12);
+  @media (--mq-medium) {
+    margin-top: var(--spacing-24);
+  }
+}
+
+.coop-u-margin-b-24 {
+  margin-bottom: var(--spacing-24);
+}
+
+.coop-u-margin-resp-b-24-12 {
+  margin-bottom: var(--spacing-12);
+  @media (--mq-medium) {
+    margin-bottom: var(--spacing-24);
+  }
+}
+
 .coop-u-margin-32 {
   margin: var(--spacing-32);
 }
@@ -176,6 +209,39 @@
   margin-bottom: var(--spacing-16);
   @media (--mq-medium) {
     margin-bottom: var(--spacing-32);
+  }
+}
+
+.coop-u-margin-48 {
+  margin: var(--spacing-48);
+}
+
+.coop-u-margin-48-24 {
+  margin: var(--spacing-24);
+  @media (--mq-medium) {
+    margin: var(--spacing-48);
+  }
+}
+
+.coop-u-margin-t-48 {
+  margin-top: var(--spacing-48);
+}
+
+.coop-u-margin-resp-t-48-24 {
+  margin-top: var(--spacing-24);
+  @media (--mq-medium) {
+    margin-top: var(--spacing-48);
+  }
+}
+
+.coop-u-margin-b-48 {
+  margin-bottom: var(--spacing-48);
+}
+
+.coop-u-margin-resp-b-48-24 {
+  margin-bottom: var(--spacing-24);
+  @media (--mq-medium) {
+    margin-bottom: var(--spacing-48);
   }
 }
 
@@ -348,6 +414,39 @@
   }
 }
 
+.coop-u-padding-24 {
+  padding: var(--spacing-24);
+}
+
+.coop-u-padding-resp-24-12 {
+  padding: var(--spacing-12);
+  @media (--mq-medium) {
+    padding: var(--spacing-24);
+  }
+}
+
+.coop-u-padding-t-24 {
+  padding-top: var(--spacing-24);
+}
+
+.coop-u-padding-resp-t-24-12 {
+  padding-top: var(--spacing-12);
+  @media (--mq-medium) {
+    padding-top: var(--spacing-24);
+  }
+}
+
+.coop-u-padding-b-24 {
+  padding-bottom: var(--spacing-24);
+}
+
+.coop-u-padding-resp-b-24-12 {
+  padding-bottom: var(--spacing-12);
+  @media (--mq-medium) {
+    padding-bottom: var(--spacing-24);
+  }
+}
+
 .coop-u-padding-32 {
   padding: var(--spacing-32);
 }
@@ -378,6 +477,39 @@
   padding-bottom: var(--spacing-16);
   @media (--mq-medium) {
     padding-bottom: var(--spacing-32);
+  }
+}
+
+.coop-u-padding-48 {
+  padding: var(--spacing-48);
+}
+
+.coop-u-padding-resp-48-24 {
+  padding: var(--spacing-24);
+  @media (--mq-medium) {
+    padding: var(--spacing-48);
+  }
+}
+
+.coop-u-padding-t-48 {
+  padding-top: var(--spacing-48);
+}
+
+.coop-u-padding-resp-t-48-24 {
+  padding-top: var(--spacing-24);
+  @media (--mq-medium) {
+    padding-top: var(--spacing-48);
+  }
+}
+
+.coop-u-padding-b-48 {
+  padding-bottom: var(--spacing-48);
+}
+
+.coop-u-padding-resp-b-48-24 {
+  padding-bottom: var(--spacing-24);
+  @media (--mq-medium) {
+    padding-bottom: var(--spacing-48);
   }
 }
 

--- a/packages/foundations-vars/src/_layout.css
+++ b/packages/foundations-vars/src/_layout.css
@@ -1,23 +1,26 @@
 :root {
   /* Spacing */
   --spacing-64: 4rem;
+  --spacing-48: 3rem;
   --spacing-32: 2rem;
+  --spacing-24: 1.5rem;
   --spacing-16: 1rem;
+  --spacing-12: 0.75rem;
   --spacing-8: 0.5rem;
   --spacing-4: 0.25rem;
   --spacing-2: 0.125rem;
 
   /* Legacy spacing */
   /* Spacing: Base */
-  --spacing-base: 2rem;
-  --spacing-base--3-4: 1.5rem;
+  --spacing-base: var(--spacing-32);
+  --spacing-base--3-4: var(--spacing-24);
   --spacing-base--1-2: var(--spacing-16);
   --spacing-base--1-4: var(--spacing-8);
   --spacing-base--1-8: var(--spacing-2);
 
   /* Spacing: Medium */
-  --spacing-medium: 4rem;
-  --spacing-medium--3-4: 3rem;
+  --spacing-medium: var(--spacing-64);
+  --spacing-medium--3-4: var(--spacing-48);
   --spacing-medium--1-2: var(--spacing-32);
   --spacing-medium--1-4: var(--spacing-16);
   --spacing-medium--1-8: var(--spacing-8);


### PR DESCRIPTION
We often use in-between spacing units with a bit of a `calc()` hack:

**Before**
```css
calc(var(--spacing-16) * 1.5); // 24px
```

**After**
```css
var(--spacing-24); // 24px
```

This PR adds them as base CSS custom properties instead.