### PR TITLE
remove space at end of else block

### DIFF
--- a/packages/shared-component--statement/src/statement.html
+++ b/packages/shared-component--statement/src/statement.html
@@ -3,7 +3,7 @@
 {% set backgroundColour = '' %}
 {% if content.background and content.background %}
 {% set backgroundColour = 'coop-c-statement-block--' + content.background.id %}
-{% else % }
+{% else %}
 {% set backgroundColour = 'coop-c-statement-block--white' %}
 {% endif %}
 


### PR DESCRIPTION
There was a space at the end of an else statement causing the statement macro to error 
![Screenshot 2020-09-14 at 16 07 04](https://user-images.githubusercontent.com/58665676/93103341-6bb03180-f6a4-11ea-88fc-43354bdac290.png)
