### PR TITLE
Don't trigger full browser reload when only CSS changes etc

### DIFF
--- a/design-system/gulpfile.js
+++ b/design-system/gulpfile.js
@@ -126,12 +126,14 @@ function vendorjs() {
     'node_modules/coop-frontend-toolkit/scripts/vendor/**/*',
     src + '_js/vendor/**/*'
   ], { follow: true })
+    .pipe(changed(dest_paths.scripts + '/vendor'))
     .pipe(gulp.dest(dest_paths.scripts + '/vendor'));
 }
 
 // Static assets
 function assets() {
   return gulp.src(src_paths.assets, { follow: true })
+    .pipe(changed(dest_paths.assets))
     .pipe(gulp.dest(dest_paths.assets))
     .pipe(connect.reload());
 }

--- a/design-system/gulpfile.js
+++ b/design-system/gulpfile.js
@@ -2,6 +2,7 @@
 
 const gulp = require('gulp');
 const sourcemaps = require('gulp-sourcemaps');
+const changed = require('gulp-changed');
 const connect = require('gulp-connect');
 const concat = require('gulp-concat');
 const include = require('gulp-include');
@@ -73,6 +74,7 @@ function copyComponents() {
     'node_modules/@coopdigital/**/*.{pcss,css,html,jpg,jpeg,gif,png,webp,svg}',
     '!node_modules/@coopdigital/**/node_modules/**',
   ], { follow: true })
+    .pipe(changed('src/_includes/pattern-library/components'))
     .pipe(gulp.dest('src/_includes/pattern-library/components'))
     .pipe(gulp.dest('build/pattern-library/components/packages'))
 }

--- a/design-system/package-lock.json
+++ b/design-system/package-lock.json
@@ -288,6 +288,12 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -3591,6 +3597,31 @@
         }
       }
     },
+    "gulp-changed": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-4.0.2.tgz",
+      "integrity": "sha512-rAvQt+ByaqrMuJLwucvxC+MC02Vh8ksiJ16hoQlk4xnmlHiLJMque2aXXQMmyocQac3RIjNRcyr7iG1TNH15GA==",
+      "dev": true,
+      "requires": {
+        "make-dir": "^3.0.0",
+        "plugin-error": "^1.0.1",
+        "replace-ext": "^1.0.0",
+        "through2": "^3.0.1",
+        "touch": "^3.1.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "gulp-concat": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
@@ -5529,6 +5560,15 @@
       "version": "1.1.60",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
       "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA=="
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -8029,6 +8069,15 @@
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
           "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         }
+      }
+    },
+    "touch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "dev": true,
+      "requires": {
+        "nopt": "~1.0.10"
       }
     },
     "trim-newlines": {

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "autoprefixer": "^9.8.6",
     "cssnano": "^4.1.10",
+    "gulp-changed": "^4.0.2",
     "postcss-calc": "^7.0.3",
     "postcss-custom-media": "^7.0.8",
     "postcss-custom-properties": "^9.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1520,8 +1520,7 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -6467,6 +6466,37 @@
 				"vinyl-sourcemaps-apply": "^0.2.1"
 			},
 			"dependencies": {
+				"through2": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+					"integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+					"requires": {
+						"inherits": "^2.0.4",
+						"readable-stream": "2 || 3"
+					}
+				}
+			}
+		},
+		"gulp-changed": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-4.0.2.tgz",
+			"integrity": "sha512-rAvQt+ByaqrMuJLwucvxC+MC02Vh8ksiJ16hoQlk4xnmlHiLJMque2aXXQMmyocQac3RIjNRcyr7iG1TNH15GA==",
+			"requires": {
+				"make-dir": "^3.0.0",
+				"plugin-error": "^1.0.1",
+				"replace-ext": "^1.0.0",
+				"through2": "^3.0.1",
+				"touch": "^3.1.0"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
 				"through2": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
@@ -13570,6 +13600,24 @@
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
 					"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+				}
+			}
+		},
+		"touch": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+			"integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+			"requires": {
+				"nopt": "~1.0.10"
+			},
+			"dependencies": {
+				"nopt": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+					"integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+					"requires": {
+						"abbrev": "1"
+					}
 				}
 			}
 		},

--- a/packages/shared-component--totaliser/dist/totaliser.html
+++ b/packages/shared-component--totaliser/dist/totaliser.html
@@ -16,7 +16,7 @@
         <path class="coop-u-brand-membership-pink-bright-stroke" d="M0 185h26.376c17.673 0 32-14.327 32-32V36c0-17.673 14.327-32 32-32H205" stroke-width="8" vector-effect="non-scaling-stroke"/>
       </svg>
 
-      <svg class="coop-c-totaliser__connector coop-c-totaliser__connector--right" viewBox="0 0 203 81" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+      <svg class="coop-c-totaliser__connector coop-c-totaliser__connector--right" viewBox="0 0 203 81" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
         <path class="coop-u-brand-membership-pink-bright-stroke" d="M0 77h28.654c17.673 0 32-14.327 32-32v-75c0-17.673 14.327-32 32-32H213" stroke-width="8" vector-effect="non-scaling-stroke"/>
       </svg>
     </section>

--- a/packages/shared-component--totaliser/src/totaliser.html
+++ b/packages/shared-component--totaliser/src/totaliser.html
@@ -14,7 +14,7 @@
       <svg class="coop-c-totaliser__connector coop-c-totaliser__connector--left" viewBox="0 0 205 130" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
         <path class="coop-u-brand-membership-pink-bright-stroke" d="M0 185h26.376c17.673 0 32-14.327 32-32V36c0-17.673 14.327-32 32-32H205" stroke-width="8" vector-effect="non-scaling-stroke"/>
       </svg>
-      <svg class="coop-c-totaliser__connector coop-c-totaliser__connector--right" viewBox="0 0 203 81" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+      <svg class="coop-c-totaliser__connector coop-c-totaliser__connector--right" viewBox="0 0 203 81" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
         <path class="coop-u-brand-membership-pink-bright-stroke" d="M0 77h28.654c17.673 0 32-14.327 32-32v-75c0-17.673 14.327-32 32-32H213" stroke-width="8" vector-effect="non-scaling-stroke"/>
       </svg>
     </section>


### PR DESCRIPTION
Speeds up local development a little more:

1. Skip `copyComponents()` for unchanged files
2. Skip `vendorjs()` and `assets()` for unchanged files
3. Removes a stray `fill` from **@coopdigital/shared-component--totaliser**

Prevents `connect.reload()` being fired unnecessarily, keeping **livereload** nice and fast.