### PR TITLE
Add cache-busting timestamp to CSS/JS assets

### DIFF
--- a/design-system/src/_layouts/blank-full.html
+++ b/design-system/src/_layouts/blank-full.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-    <link rel="stylesheet" type="text/css" href="/assets/css/main.css">
+    <link rel="stylesheet" type="text/css" href="/assets/css/main.css?v={{ site.time | date: '%s' }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link rel="icon" href="{{ site.baseurl }}/favicon.ico" type="image/x-icon">
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-87772770-1"></script>
@@ -18,6 +18,6 @@
     </script>
 </head>
 <body>
-    {{ content }}  
+    {{ content }}
 </body>
 </html>

--- a/design-system/src/_layouts/blank.html
+++ b/design-system/src/_layouts/blank.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-    <link rel="stylesheet" type="text/css" href="/assets/css/main.css">
+    <link rel="stylesheet" type="text/css" href="/assets/css/main.css?v={{ site.time | date: '%s' }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link rel="icon" href="{{ site.baseurl }}/favicon.ico" type="image/x-icon">
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-87772770-1"></script>

--- a/design-system/src/_layouts/default.html
+++ b/design-system/src/_layouts/default.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-    <link rel="stylesheet" type="text/css" href="/assets/css/main.css">
+    <link rel="stylesheet" type="text/css" href="/assets/css/main.css?v={{ site.time | date: '%s' }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link rel="icon" href="{{ site.baseurl }}/favicon.ico" type="image/x-icon">
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-167987980-1"></script>
@@ -30,7 +30,7 @@
     <script src="https://code.jquery.com/jquery-1.12.1.min.js" integrity="sha256-I1nTg78tSrZev3kjvfdM5A5Ak/blglGzlaZANLPDl3I=" crossorigin="anonymous"></script>
     <script>window.jQuery || document.write('<script src="/assets/js/vendor/jquery-1.12.1.min.js"><\/script>')</script>
     <script src="https://cdn.rawgit.com/filamentgroup/fixed-sticky/master/fixedsticky.js" crossorigin="anonymous"></script>
-    <script src="/assets/js/main.js"></script>
-    <script src="/assets/js/vendor/prism.js"></script>
+    <script src="/assets/js/main.js?v={{ site.time | date: '%s' }}"></script>
+    <script src="/assets/js/vendor/prism.js?v={{ site.time | date: '%s' }}"></script>
 </body>
 </html>


### PR DESCRIPTION
We're struggling to share updates to the Design System without cache-busting in place.

This PR adds primitive cache-busting with a unix time stamp `?v=` on CSS/JS includes:

### Input
```html
<link rel="stylesheet" type="text/css" href="/assets/css/main.css?v={{ site.time | date: '%s' }}">
```

### Output
```html
<link rel="stylesheet" type="text/css" href="/assets/css/main.css?v=1600422943">
```