### PR TITLE
Add support for links with icons

### DIFF
--- a/design-system/src/_includes/pattern-library/foundations/foundations-links/links.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-links/links.html
@@ -1,2 +1,17 @@
 
-<p><a href="#">Start making your will</a></p>
+<!-- Text link -->
+<p><a class="coop-t-link" href="#">Start making your will</a></p>
+
+<h3>Links with icons</h3>
+
+<!-- Text link with arrow SVG (pink) -->
+<p><a class="coop-t-link coop-t-link--arrow" href="#">More about offers<svg class="coop-t-link__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 20" aria-hidden="true" focusable="false"><path class="coop-u-brand-membership-pink-bright-fill" d="M13.89 0L11.4 2.46l5.87 5.8H0v3.48h17.28l-5.88 5.8L13.89 20 24 10z" stroke="none"/></svg></a></p>
+
+<!-- Text link with arrow SVG (orange) -->
+<p><a class="coop-t-link coop-t-link--arrow" href="#">More about offers<svg class="coop-t-link__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 20" aria-hidden="true" focusable="false"><path class="coop-u-brand-membership-orange-bright-fill" d="M13.89 0L11.4 2.46l5.87 5.8H0v3.48h17.28l-5.88 5.8L13.89 20 24 10z" stroke="none"/></svg></a></p>
+
+<!-- Text link with arrow SVG (yellow) -->
+<p><a class="coop-t-link coop-t-link--arrow" href="#">More about offers<svg class="coop-t-link__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 20" aria-hidden="true" focusable="false"><path class="coop-u-brand-membership-yellow-brown-bright-fill" d="M13.89 0L11.4 2.46l5.87 5.8H0v3.48h17.28l-5.88 5.8L13.89 20 24 10z" stroke="none"/></svg></a></p>
+
+<!-- Text link with arrow SVG (green) -->
+<p><a class="coop-t-link coop-t-link--arrow" href="#">More about offers<svg class="coop-t-link__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 20" aria-hidden="true" focusable="false"><path class="coop-u-brand-membership-green-bright-fill" d="M13.89 0L11.4 2.46l5.87 5.8H0v3.48h17.28l-5.88 5.8L13.89 20 24 10z" stroke="none"/></svg></a></p>

--- a/packages/foundations-typography/package.json
+++ b/packages/foundations-typography/package.json
@@ -20,9 +20,11 @@
     "directory": "packages/foundations-typography"
   },
   "devDependencies": {
+    "@coopdigital/foundations-colors": "^2.1.17",
     "@coopdigital/foundations-vars": "^3.2.2"
   },
   "peerDependencies": {
+    "@coopdigital/foundations-colors": ">= 2.1.17 < 3",
     "@coopdigital/foundations-vars": ">= 3.1.2 < 4"
   },
   "publishConfig": {

--- a/packages/foundations-typography/src/typography.pcss
+++ b/packages/foundations-typography/src/typography.pcss
@@ -291,6 +291,37 @@ button.coop-t-link {
   }
 }
 
+.coop-t-link--arrow {
+  display: inline-block;
+  color: var(--color-text);
+
+  & .coop-t-link__icon {
+    margin: 0 0 0 0.6em; /* 12px */
+    transform: translateX(-0.1em); /* -2px */
+  }
+
+  &:hover,
+  &:focus {
+    color: var(--color-text);
+  }
+
+  &:hover .coop-t-link__icon,
+  &:focus .coop-t-link__icon {
+    transform: translateX(0);
+  }
+}
+
+.coop-t-link__icon {
+  position: relative;
+  top: -0.05em; /* -1px */
+  display: inline-block;
+  width: 1.2em; /* 24px */
+  height: 1em; /* 20px */
+  margin: 0 0.6em 0 0; /* 12px */
+  vertical-align: middle;
+  transition: transform 0.15s ease-in;
+}
+
 hr,
 .coop-t-hr {
   display: block;


### PR DESCRIPTION
As used by the new membership components.

But this PR proposes a generic link + icon HTML pattern for any other use case:

```html
<a class="coop-t-link" href="#">
  More about offers
  
  <!-- Icon with colour fill -->
  <svg class="coop-t-link__icon">
    <path class="coop-u-brand-fill"/>
  </svg>
</a>
```

As the icon is decorative, we'll also add to the SVG:

```html
<svg aria-hidden="true" focusable="false"></svg>
```

![Arrows](https://user-images.githubusercontent.com/415517/93598217-4c6f1800-f9b4-11ea-9210-cb5b3f29007d.png)
