### PR TITLE
Add “Co-operate explainer” component

### DIFF
--- a/packages/shared-component--cooperate/.npmrc
+++ b/packages/shared-component--cooperate/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/shared-component--cooperate/dist/cooperate.html
+++ b/packages/shared-component--cooperate/dist/cooperate.html
@@ -1,0 +1,43 @@
+<div class="coop-c-cooperate-explainer coop-c-signpost-list coop-u-brand-membership-green-light-bg">
+  <div class="coop-c-signpost-list__inner">
+    <h4 class="coop-c-cooperate-explainer__title coop-c-signpost-list__title coop-c-cooperate-underlined">
+      <svg viewBox="0 0 179 11" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" aria-hidden="true" focusable="false"><path class="coop-u-brand-fill" fill-rule="evenodd" clip-rule="evenodd" d="M178.805 9.374c.101-1.653.151-1.846-.24-2.85.202-.996-.207-1.168-1.212-1.153l.006-.22c.411-.408.184-.191.935-.174-.582-2.227-3.62-1.711-5.534-2.237-4.861-1.34-13.124-1.163-18.904-1.362-11.328-.047-22.662-.09-33.99-.135-7.139-.058-14.277-.119-21.416-.176C92.811 1.01 87.172.95 81.536.895c-14.549.381-29.1.758-43.646 1.138-9.575.188-19.156.372-28.73.56C6.887 2.941.893 1.25-.037 4.107c.206.082.408.164.614.25-.211.134-.42.272-.63.406l-.011.436c5.31 3.45 17.233 2.754 23.061 2.659 3.209-.052 8.799 1.624 10.726-.568.842 1.502 4.768 1.326 6.334 1.183l29.18.12 27.78.267c6.62.103 13.242.211 19.861.315 9.566.177 19.138.357 28.704.533l18.016-.427 14.882.729c.082-.773-.217-.427.324-.637zm-36.802-5.73l.006-.22c.158-.064.313-.129.471-.197l.31.015c.048.147.095.297.146.444-.313-.012-.623-.027-.933-.042zm19.406-.143l.776.038c-.468.43-.281.339-.776-.038zm4.02.633c.055-.141.11-.286.167-.428l.157.008c-.109.139-.215.282-.324.42z" fill="#00B1E7"/></svg>
+      <span>Co-operate</span>
+    </h4>
+
+    <div class="coop-c-signpost-list__body">
+      <p>Our online community centre helps people find an activity, join a group or set up their own.</p>
+    </div>
+
+    <div class="coop-c-signpost-list__grid coop-l-grid">
+      <div class="coop-l-grid__item coop-l-grid__item--small-6">
+        <div class="coop-c-signpost-list__item coop-c-signpost">
+          <a href="#" class="coop-c-signpost__link">
+            <div class="coop-c-signpost__content">
+              <h3 class="coop-c-signpost__title">Find activities</h3>
+              <span class="coop-c-signpost__icon" aria-hidden="true">
+                <svg class="coop-c-signpost__icon__svg" viewBox="0 0 16 29" focusable="false">
+                  <path d="M1.909 28.11a1.575 1.575 0 0 1-1.115-2.691L11.713 14.5.793 3.58a1.575 1.575 0 1 1 2.23-2.228l12.033 12.033a1.575 1.575 0 0 1 0 2.229L3.023 27.647c-.307.308-.71.463-1.114.463z">
+                </svg>
+              </span>
+            </div>
+          </a>
+        </div>
+      </div>
+      <div class="coop-l-grid__item coop-l-grid__item--small-6">
+        <div class="coop-c-signpost-list__item coop-c-signpost">
+          <a href="#" class="coop-c-signpost__link">
+            <div class="coop-c-signpost__content">
+              <h3 class="coop-c-signpost__title">Find groups</h3>
+              <span class="coop-c-signpost__icon" aria-hidden="true">
+                <svg class="coop-c-signpost__icon__svg" viewBox="0 0 16 29" focusable="false">
+                  <path d="M1.909 28.11a1.575 1.575 0 0 1-1.115-2.691L11.713 14.5.793 3.58a1.575 1.575 0 1 1 2.23-2.228l12.033 12.033a1.575 1.575 0 0 1 0 2.229L3.023 27.647c-.307.308-.71.463-1.114.463z">
+                </svg>
+              </span>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/packages/shared-component--cooperate/package.json
+++ b/packages/shared-component--cooperate/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@coopdigital/shared-component--cooperate",
+  "version": "1.0.4",
+  "description": "Co-op Shared Component: Co-operate explainer",
+  "main": "dist/cooperate.css",
+  "style": "src/cooperate.pcss",
+  "author": "@coopdigital",
+  "contributors": [
+    "Colin Rotherham <work@colinr.com> (https://github.com/colinrotherham)"
+  ],
+  "private": false,
+  "files": [
+    "dist",
+    "src"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coopdigital/coop-frontend.git",
+    "directory": "packages/shared-component--cooperate"
+  },
+  "devDependencies": {
+    "@coopdigital/foundations-grid": "^2.0.8",
+    "@coopdigital/foundations-vars": "^3.2.2",
+    "@coopdigital/shared-component--signpost": "^2.1.17",
+    "@coopdigital/shared-component--signpostlist": "^1.0.4"
+  },
+  "peerDependencies": {
+    "@coopdigital/foundations-grid": ">= 2.0.7 < 3",
+    "@coopdigital/foundations-vars": ">= 3.1.2 < 4",
+    "@coopdigital/shared-component--signpost": ">= 2.1.17 < 3",
+    "@coopdigital/shared-component--signpostlist": ">= 1.0.4 < 2"
+  },
+  "bugs": {
+    "url": "https://github.com/coopdigital/coop-frontend/issues"
+  },
+  "homepage": "https://github.com/coopdigital/coop-frontend/tree/master/packages/shared-component--cooperate#readme",
+  "keywords": [
+    "card",
+    "content",
+    "signpost",
+    "co-operate"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/shared-component--cooperate/readme.md
+++ b/packages/shared-component--cooperate/readme.md
@@ -1,0 +1,2 @@
+# Component card
+Co-operate explainer component

--- a/packages/shared-component--cooperate/src/cooperate.html
+++ b/packages/shared-component--cooperate/src/cooperate.html
@@ -1,0 +1,43 @@
+<div class="coop-c-cooperate-explainer coop-c-signpost-list coop-u-brand-membership-green-light-bg">
+  <div class="coop-c-signpost-list__inner">
+    <h4 class="coop-c-cooperate-explainer__title coop-c-signpost-list__title coop-c-cooperate-underlined">
+      <svg viewBox="0 0 179 11" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" aria-hidden="true" focusable="false"><path class="coop-u-brand-fill" fill-rule="evenodd" clip-rule="evenodd" d="M178.805 9.374c.101-1.653.151-1.846-.24-2.85.202-.996-.207-1.168-1.212-1.153l.006-.22c.411-.408.184-.191.935-.174-.582-2.227-3.62-1.711-5.534-2.237-4.861-1.34-13.124-1.163-18.904-1.362-11.328-.047-22.662-.09-33.99-.135-7.139-.058-14.277-.119-21.416-.176C92.811 1.01 87.172.95 81.536.895c-14.549.381-29.1.758-43.646 1.138-9.575.188-19.156.372-28.73.56C6.887 2.941.893 1.25-.037 4.107c.206.082.408.164.614.25-.211.134-.42.272-.63.406l-.011.436c5.31 3.45 17.233 2.754 23.061 2.659 3.209-.052 8.799 1.624 10.726-.568.842 1.502 4.768 1.326 6.334 1.183l29.18.12 27.78.267c6.62.103 13.242.211 19.861.315 9.566.177 19.138.357 28.704.533l18.016-.427 14.882.729c.082-.773-.217-.427.324-.637zm-36.802-5.73l.006-.22c.158-.064.313-.129.471-.197l.31.015c.048.147.095.297.146.444-.313-.012-.623-.027-.933-.042zm19.406-.143l.776.038c-.468.43-.281.339-.776-.038zm4.02.633c.055-.141.11-.286.167-.428l.157.008c-.109.139-.215.282-.324.42z" fill="#00B1E7"/></svg>
+      <span>Co-operate</span>
+    </h4>
+
+    <div class="coop-c-signpost-list__body">
+      <p>Our online community centre helps people find an activity, join a group or set up their own.</p>
+    </div>
+
+    <div class="coop-c-signpost-list__grid coop-l-grid">
+      <div class="coop-l-grid__item coop-l-grid__item--small-6">
+        <div class="coop-c-signpost-list__item coop-c-signpost">
+          <a href="#" class="coop-c-signpost__link">
+            <div class="coop-c-signpost__content">
+              <h3 class="coop-c-signpost__title">Find activities</h3>
+              <span class="coop-c-signpost__icon" aria-hidden="true">
+                <svg class="coop-c-signpost__icon__svg" viewBox="0 0 16 29" focusable="false">
+                  <path d="M1.909 28.11a1.575 1.575 0 0 1-1.115-2.691L11.713 14.5.793 3.58a1.575 1.575 0 1 1 2.23-2.228l12.033 12.033a1.575 1.575 0 0 1 0 2.229L3.023 27.647c-.307.308-.71.463-1.114.463z">
+                </svg>
+              </span>
+            </div>
+          </a>
+        </div>
+      </div>
+      <div class="coop-l-grid__item coop-l-grid__item--small-6">
+        <div class="coop-c-signpost-list__item coop-c-signpost">
+          <a href="#" class="coop-c-signpost__link">
+            <div class="coop-c-signpost__content">
+              <h3 class="coop-c-signpost__title">Find groups</h3>
+              <span class="coop-c-signpost__icon" aria-hidden="true">
+                <svg class="coop-c-signpost__icon__svg" viewBox="0 0 16 29" focusable="false">
+                  <path d="M1.909 28.11a1.575 1.575 0 0 1-1.115-2.691L11.713 14.5.793 3.58a1.575 1.575 0 1 1 2.23-2.228l12.033 12.033a1.575 1.575 0 0 1 0 2.229L3.023 27.647c-.307.308-.71.463-1.114.463z">
+                </svg>
+              </span>
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/packages/shared-component--cooperate/src/cooperate.pcss
+++ b/packages/shared-component--cooperate/src/cooperate.pcss
@@ -1,0 +1,27 @@
+/* Co-operate explainer */
+
+@import "@coopdigital/foundations-vars";
+
+.coop-c-cooperate-explainer__title {
+  font-size: var(--type-h3-s);
+
+  @media (--mq-medium) {
+    font-size: var(--type-h3-l);
+  }
+}
+
+.coop-c-cooperate-underlined {
+  position: relative;
+  display: inline-block;
+  margin-bottom: var(--spacing-48);
+
+  & svg {
+    position: absolute;
+    z-index: 0;
+    left: 0;
+    /* 12px at 26px font-size */
+    bottom: calc(12 / 26 * -1em);
+    height: calc(12 / 26 * 1em);
+    width: 130%;
+  }
+}


### PR DESCRIPTION
This PR adds a new `@coopdigital/shared-component--cooperate` "Co-operate explainer" component.

It's a wrapper for `@coopdigital/shared-component--signpostlist`, extending it with Co-operate colours and an underline.

![Co-operate](https://user-images.githubusercontent.com/415517/93754481-b9bfba80-fbf9-11ea-8767-ffb0822d574e.png)
