### PR TITLE
add custom html macro for appdownload component

### DIFF
--- a/packages/shared-component--app/src/app-download.html
+++ b/packages/shared-component--app/src/app-download.html
@@ -90,3 +90,38 @@
   </div>
 </aside>
 {% endmacro %}
+
+{% macro customHtml(content, config='') %}
+  <aside class="coop-c-app-download {{ content.backgroundclass}}">
+    <div class="coop-c-app-download__inner coop-u-clearfix">
+      <div class="coop-c-app-download__content coop-u-clearfix">
+        <h2 class="coop-c-app-download__title">{{ content.title}}</h2>
+        <div class="coop-c-app-download__body">
+          {{ content.downloadbodytext|safe}}
+        </div>
+        <div class="coop-c-app-download__about">
+          {{ content.downloadabout|safe}}
+        </div>
+      </div>
+      {% set altText = content.imagealttext %}
+      {%
+        set imageDimensions = {
+          'width': content.imagewidth|int,
+          'height': content.imageheight|int
+        }
+      %}
+      <figure class="coop-c-app-download__media coop-c-app-download__media--align-bottom {{content.imagebackgroundclass}}">
+        <picture class="coop-c-app-download__picture">
+          <!-- if browser supports webp image format, serve the webp format-->
+          <source media="(min-width: 48em)" srcset="{{ content.image }}?fm=webp&amp;q=60&amp;fit=thumb&amp;w={{ imageDimensions.width }}&amp;h={{ imageDimensions.height }} 1x, {{ content.image }}?fm=webp&amp;q=60&amp;fit=thumb&amp;w={{ imageDimensions.width * 2}}&amp;h={{ imageDimensions.height *2 }} 2x" type="image/webp" />
+              <source srcset="{{ content.image }}?fm=webp&amp;q=60&amp;fit=thumb&amp;w={{ imageDimensions.width }}&amp;h={{ imageDimensions.height }} 1x, {{ content.image }}?fm=webp&amp;q=60&amp;fit=thumb&amp;w={{ imageDimensions.width * 2}}&amp;h={{ imageDimensions.height *2 }} 2x" type="image/webp" />
+              <!-- if no webp supported then default to transparent PNG -->
+              <source media="(min-width: 48em)" srcset="{{content.image}}?fm=png&amp;q=60 1x, {{content.image}}?fm=png&amp;q=60 2x" type="image/png">
+              <source srcset="{{content.image}}?fm=png&amp;q=60 1x, {{content.image}}?fm=png&amp;q=60 2x" type="image/png">
+              <!-- fallback -->
+              <img class="coop-c-app-download__image" src="{{content.image}}" alt="{{altText}}">
+        </picture>
+      </figure>
+    </div>
+  </aside>
+{% endmacro %}


### PR DESCRIPTION
New macro so that we can create a custom html template for app download section that currently doesn't have the compoenents in contentful to be built.