### PR TITLE
Simplify checkbox/radio HTML

### DIFF
--- a/design-system/src/_includes/pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html
+++ b/design-system/src/_includes/pattern-library/foundations/foundations-checkboxes-and-radio-buttons/checkboxes-and-radio-buttons.html
@@ -1,168 +1,152 @@
 
 <!-- Checkboxes and radios -->
-<form class="coop-form coop-c-form-choice">
+<form class="coop-form">
     <h3>Checkboxes and radios</h3>
 
-    <div class="coop-form__row">
-        <fieldset class="coop-c-form-choice">
-            <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-1" id="checkbox-1-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-1-1" class="coop-form__label coop-c-form-choice__label">a business</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-1" id="checkbox-1-2" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-1-2" class="coop-form__label coop-c-form-choice__label">agricultural property</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-1" id="checkbox-1-3" value="3" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-1-3" class="coop-form__label coop-c-form-choice__label">foreign property</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-1" id="checkbox-1-4" value="4" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-1-4" class="coop-form__label coop-c-form-choice__label">trademarks or patents</label>
-            </div>
-        </fieldset>
-    </div>
-    <div class="coop-form__row">
-        <fieldset class="coop-c-form-choice">
-            <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
-            <div class="coop-c-form-choice">
-                <input type="radio" name="radio-1" id="radio-1-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-                <label class="coop-form__label coop-c-form-choice__label" for="radio-1-1">Free delivery</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="radio" name="radio-1" id="radio-1-2" value="2" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-                <label class="coop-form__label coop-c-form-choice__label" for="radio-1-2">Next day delivery — £4.99</label>
-            </div>
-        </fieldset>
-    </div>
+    <fieldset class="coop-form__row">
+        <legend class="coop-form__label">Do you own:</legend>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-1" id="checkbox-1-1" value="1" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-1-1" class="coop-form__label">a business</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-1" id="checkbox-1-2" value="2" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-1-2" class="coop-form__label">agricultural property</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-1" id="checkbox-1-3" value="3" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-1-3" class="coop-form__label">foreign property</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-1" id="checkbox-1-4" value="4" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-1-4" class="coop-form__label">trademarks or patents this is a really long label that needs to wrap a bit</label>
+        </div>
+    </fieldset>
+    <fieldset class="coop-form__row">
+        <legend class="coop-form__label">Type of delivery</legend>
+        <div class="coop-form__choice">
+            <input type="radio" name="radio-1" id="radio-1-1" value="1" class="coop-form__field coop-form__radio">
+            <label class="coop-form__label" for="radio-1-1">Free delivery</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="radio" name="radio-1" id="radio-1-2" value="2" class="coop-form__field coop-form__radio">
+            <label class="coop-form__label" for="radio-1-2">Next day delivery — £4.99</label>
+        </div>
+    </fieldset>
 </form>
 
 <!-- Checkboxes and radios with hint -->
-<form class="coop-form coop-c-form-choice">
+<form class="coop-form">
     <h3>Checkboxes and radios with hint</h3>
 
-    <div class="coop-form__row">
-        <fieldset class="coop-c-form-choice" aria-describedby="checkbox-2-hint">
-            <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
-            <p id="checkbox-2-hint" class="coop-form__hint">Select all that apply</p>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-2" id="checkbox-2-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-2-1" class="coop-form__label coop-c-form-choice__label">a business</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-2" id="checkbox-2-2" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-2-2" class="coop-form__label coop-c-form-choice__label">agricultural property</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-2" id="checkbox-2-3" value="3" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-2-3" class="coop-form__label coop-c-form-choice__label">foreign property</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-2" id="checkbox-2-4" value="4" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-2-4" class="coop-form__label coop-c-form-choice__label">trademarks or patents</label>
-            </div>
-        </fieldset>
-    </div>
-    <div class="coop-form__row">
-        <fieldset class="coop-c-form-choice" aria-describedby="radio-2-hint">
-            <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
-            <p id="radio-2-hint" class="coop-form__hint">Select only one option</p>
-            <div class="coop-c-form-choice">
-                <input type="radio" name="radio-2" id="radio-2-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-                <label class="coop-form__label coop-c-form-choice__label" for="radio-2-1">Free delivery</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="radio" name="radio-2" id="radio-2-2" value="2" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-                <label class="coop-form__label coop-c-form-choice__label" for="radio-2-2">Next day delivery — £4.99</label>
-            </div>
-        </fieldset>
-    </div>
+    <fieldset class="coop-form__row" aria-describedby="checkbox-2-hint">
+        <legend class="coop-form__label">Do you own:</legend>
+        <p id="checkbox-2-hint" class="coop-form__hint">Select all that apply</p>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-2" id="checkbox-2-1" value="1" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-2-1" class="coop-form__label">a business</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-2" id="checkbox-2-2" value="2" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-2-2" class="coop-form__label">agricultural property</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-2" id="checkbox-2-3" value="3" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-2-3" class="coop-form__label">foreign property</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-2" id="checkbox-2-4" value="4" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-2-4" class="coop-form__label">trademarks or patents</label>
+        </div>
+    </fieldset>
+    <fieldset class="coop-form__row" aria-describedby="radio-2-hint">
+        <legend class="coop-form__label">Type of delivery</legend>
+        <p id="radio-2-hint" class="coop-form__hint">Select only one option</p>
+        <div class="coop-form__choice">
+            <input type="radio" name="radio-2" id="radio-2-1" value="1" class="coop-form__field coop-form__radio">
+            <label class="coop-form__label" for="radio-2-1">Free delivery</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="radio" name="radio-2" id="radio-2-2" value="2" class="coop-form__field coop-form__radio">
+            <label class="coop-form__label" for="radio-2-2">Next day delivery — £4.99</label>
+        </div>
+    </fieldset>
 </form>
 
 <!-- Checkboxes and radios with error message -->
-<form class="coop-form coop-c-form-choice">
+<form class="coop-form">
     <h3>Checkboxes and radios with error message</h3>
 
-    <div class="coop-form__row">
-        <fieldset class="coop-c-form-choice" aria-describedby="checkbox-3-error">
-            <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
-            <p id="checkbox-3-error" class="coop-form__error">Select options owned by you</p>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-3" id="checkbox-3-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-3-1" class="coop-form__label coop-c-form-choice__label">a business</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-3" id="checkbox-3-2" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-3-2" class="coop-form__label coop-c-form-choice__label">agricultural property</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-3" id="checkbox-3-3" value="3" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-3-3" class="coop-form__label coop-c-form-choice__label">foreign property</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-3" id="checkbox-3-4" value="4" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-3-4" class="coop-form__label coop-c-form-choice__label">trademarks or patents</label>
-            </div>
-        </fieldset>
-    </div>
-    <div class="coop-form__row">
-        <fieldset class="coop-c-form-choice" aria-describedby="radio-3-error">
-            <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
-            <p id="radio-3-error" class="coop-form__error">Select type of delivery</p>
-            <div class="coop-c-form-choice">
-                <input type="radio" name="radio-3" id="radio-3-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-                <label class="coop-form__label coop-c-form-choice__label" for="radio-3-1">Free delivery</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="radio" name="radio-3" id="radio-3-2" value="2" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-                <label class="coop-form__label coop-c-form-choice__label" for="radio-3-2">Next day delivery — £4.99</label>
-            </div>
-        </fieldset>
-    </div>
+    <fieldset class="coop-form__row" aria-describedby="checkbox-3-error">
+        <legend class="coop-form__label">Do you own:</legend>
+        <p id="checkbox-3-error" class="coop-form__error">Select options owned by you</p>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-3" id="checkbox-3-1" value="1" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-3-1" class="coop-form__label">a business</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-3" id="checkbox-3-2" value="2" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-3-2" class="coop-form__label">agricultural property</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-3" id="checkbox-3-3" value="3" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-3-3" class="coop-form__label">foreign property</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-3" id="checkbox-3-4" value="4" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-3-4" class="coop-form__label">trademarks or patents</label>
+        </div>
+    </fieldset>
+    <fieldset class="coop-form__row" aria-describedby="radio-3-error">
+        <legend class="coop-form__label">Type of delivery</legend>
+        <p id="radio-3-error" class="coop-form__error">Select type of delivery</p>
+        <div class="coop-form__choice">
+            <input type="radio" name="radio-3" id="radio-3-1" value="1" class="coop-form__field coop-form__radio">
+            <label class="coop-form__label" for="radio-3-1">Free delivery</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="radio" name="radio-3" id="radio-3-2" value="2" class="coop-form__field coop-form__radio">
+            <label class="coop-form__label" for="radio-3-2">Next day delivery — £4.99</label>
+        </div>
+    </fieldset>
 </form>
 
 <!-- Checkboxes and radios with hint and error message -->
-<form class="coop-form coop-c-form-choice">
+<form class="coop-form">
     <h3>Checkboxes and radios with hint and error message</h3>
 
-    <div class="coop-form__row">
-        <fieldset class="coop-c-form-choice" aria-describedby="checkbox-4-hint checkbox-4-error">
-            <legend class="coop-form__legend coop-c-form-choice__legend">Do you own:</legend>
-            <p id="checkbox-4-hint" class="coop-form__hint">Select all that apply</p>
-            <p id="checkbox-4-error" class="coop-form__error">Select options owned by you</p>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-4" id="checkbox-4-1" value="1" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-4-1" class="coop-form__label coop-c-form-choice__label">a business</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-4" id="checkbox-4-2" value="2" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-4-2" class="coop-form__label coop-c-form-choice__label">agricultural property</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-4" id="checkbox-4-3" value="3" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-4-3" class="coop-form__label coop-c-form-choice__label">foreign property</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="checkbox" name="checkbox-4" id="checkbox-4-4" value="4" class="coop-form__field coop-form__checkbox coop-c-form-choice__input coop-c-form-choice__input--checkbox">
-                <label for="checkbox-4-4" class="coop-form__label coop-c-form-choice__label">trademarks or patents</label>
-            </div>
-        </fieldset>
-    </div>
-    <div class="coop-form__row">
-        <fieldset class="coop-c-form-choice" aria-describedby="radio-4-hint radio-4-error">
-            <legend class="coop-form__legend coop-c-form-choice__legend">Type of delivery</legend>
-            <p id="radio-4-hint" class="coop-form__hint">Select only one option</p>
-            <p id="radio-4-error" class="coop-form__error">Select type of delivery</p>
-            <div class="coop-c-form-choice">
-                <input type="radio" name="radio-4" id="radio-4-1" value="1" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-                <label class="coop-form__label coop-c-form-choice__label" for="radio-4-1">Free delivery</label>
-            </div>
-            <div class="coop-c-form-choice">
-                <input type="radio" name="radio-4" id="radio-4-2" value="2" class="coop-form__field coop-form__radio coop-c-form-choice__input coop-c-form-choice__input--radio-button">
-                <label class="coop-form__label coop-c-form-choice__label" for="radio-4-2">Next day delivery — £4.99</label>
-            </div>
-        </fieldset>
-    </div>
+    <fieldset class="coop-form__row" aria-describedby="checkbox-4-hint checkbox-4-error">
+        <legend class="coop-form__label">Do you own:</legend>
+        <p id="checkbox-4-hint" class="coop-form__hint">Select all that apply</p>
+        <p id="checkbox-4-error" class="coop-form__error">Select options owned by you</p>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-4" id="checkbox-4-1" value="1" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-4-1" class="coop-form__label">a business</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-4" id="checkbox-4-2" value="2" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-4-2" class="coop-form__label">agricultural property</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-4" id="checkbox-4-3" value="3" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-4-3" class="coop-form__label">foreign property</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="checkbox" name="checkbox-4" id="checkbox-4-4" value="4" class="coop-form__field coop-form__checkbox">
+            <label for="checkbox-4-4" class="coop-form__label">trademarks or patents</label>
+        </div>
+    </fieldset>
+    <fieldset class="coop-form__row" aria-describedby="radio-4-hint radio-4-error">
+        <legend class="coop-form__label">Type of delivery</legend>
+        <p id="radio-4-hint" class="coop-form__hint">Select only one option</p>
+        <p id="radio-4-error" class="coop-form__error">Select type of delivery</p>
+        <div class="coop-form__choice">
+            <input type="radio" name="radio-4" id="radio-4-1" value="1" class="coop-form__field coop-form__radio">
+            <label class="coop-form__label" for="radio-4-1">Free delivery</label>
+        </div>
+        <div class="coop-form__choice">
+            <input type="radio" name="radio-4" id="radio-4-2" value="2" class="coop-form__field coop-form__radio">
+            <label class="coop-form__label" for="radio-4-2">Next day delivery — £4.99</label>
+        </div>
+    </fieldset>
 </form>

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -2,6 +2,18 @@
 
 @import "@coopdigital/foundations-vars";
 
+:root {
+  --form-choice-width: 25px;
+  --form-choice-offset-top-s: 2px;
+  --form-choice-offset-top-l: 4px;
+
+  --form-choice-button-width: 13px;
+  --form-choice-button-offset-top-s: calc(var(--form-choice-offset-top-s) + (var(--form-choice-width) - var(--form-choice-button-width)) / 2);
+  --form-choice-button-offset-top-l: calc(var(--form-choice-offset-top-l) + (var(--form-choice-width) - var(--form-choice-button-width)) / 2);
+
+  --form-choice-stroke-width: 2px;
+}
+
 .coop-form {
   margin-bottom: var(--spacing-base);
 }
@@ -252,12 +264,98 @@ select,
   }
 }
 
+/* Checkboxes and radios container */
+.coop-form__choice {
+  position: relative;
+  min-height: var(--form-choice-width);
+  margin-bottom: var(--spacing-8);
+}
+
 input[type="checkbox"],
 .coop-form__checkbox,
 input[type="radio"],
 .coop-form__radio {
   display: inline;
   cursor: pointer;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  opacity: 0;
+  z-index: 1;
+}
+
+/* Create room for fake checkbox/radio */
+.coop-form__choice .coop-form__label {
+  display: block;
+  margin: 0;
+  padding-right: var(--spacing-16);
+  padding-left: calc(var(--form-choice-width) - var(--form-choice-stroke-width) + var(--spacing-16));
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+/* Fake checkbox/radio */
+.coop-form__choice .coop-form__label::before {
+  content: "";
+  border-style: solid;
+  border-width: var(--form-choice-stroke-width);
+  border-color: var(--color-black);
+  border-radius: 15%;
+  background: transparent;
+  width: var(--form-choice-width);
+  height: var(--form-choice-width);
+  position: absolute;
+  top: var(--form-choice-offset-top-s);
+  left: 0;
+
+  @media (--mq-medium) {
+    top: var(--form-choice-offset-top-l);
+  }
+}
+
+/* Fake pressed state */
+.coop-form__choice .coop-form__label::after {
+  position: absolute;
+  top: calc((var(--form-choice-width) - var(--form-choice-button-width)) / 2 + var(--form-choice-offset-top-s));
+  left: calc((var(--form-choice-width) - var(--form-choice-button-width)) / 2);
+  width: var(--form-choice-button-width);
+  height: var(--form-choice-button-width);
+  background: black;
+  opacity: 0;
+  content: "";
+
+  @media (--mq-medium) {
+    top: calc((var(--form-choice-width) - var(--form-choice-button-width)) / 2 + var(--form-choice-offset-top-l));
+  }
+}
+
+/* Fake pressed state (rotated for checkbox) */
+.coop-form__checkbox + .coop-form__label::after {
+  background: none;
+  border: solid;
+  border-width: 0 0 3px 3px;
+  transform: rotate(-45deg);
+  border-top-color: transparent;
+  height: calc(var(--form-choice-button-width) / 2);
+  margin-top: 2px;
+}
+
+.coop-form__radio + .coop-form__label::before,
+.coop-form__radio + .coop-form__label::after {
+  border-radius: 50%;
+}
+
+.coop-form__choice :focus + .coop-form__label::before {
+  outline-offset: 3px;
+  outline: 2px solid var(--color-link--focus);
+  transition: none;
+}
+
+.coop-form__choice :checked + .coop-form__label::after {
+  opacity: 1;
 }
 
 .coop-form__field--inline {
@@ -312,98 +410,6 @@ label + .coop-form__error,
 .coop-label__hint + .coop-form__error,
 .coop-form__hint + .coop-form__error {
   margin-top: var(--spacing-16);
-}
-
-.coop-c-form-choice {
-  position: relative;
-  margin: 0;
-}
-
-.coop-c-form-choice__legend {
-  margin-bottom: var(--spacing-4);
-  font-size: var(--type-body-s);
-
-  @media (--mq-medium) {
-    margin-bottom: var(--spacing-8);
-    font-size: var(--type-body-l);
-  }
-}
-
-.coop-c-form-choice__input {
-  cursor: pointer;
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 16px;
-  height: 16px;
-  margin: 0;
-  opacity: 0;
-  z-index: 1;
-}
-
-.coop-c-form-choice__label {
-  cursor: pointer;
-  margin: 0;
-  padding: 0px 10px 10px 39px;
-  display: block;
-  line-height: 1.6;
-  -ms-touch-action: manipulation;
-  touch-action: manipulation;
-}
-
-.coop-c-form-choice__input:focus + .coop-c-form-choice__label::before {
-  outline-offset: 3px;
-  outline: 2px solid var(--color-link--focus);
-  transition: none;
-}
-
-.coop-c-form-choice__input + .coop-c-form-choice__label::before {
-  content: "";
-  border: 2px solid;
-  border-color: var(--color-black);
-  background: transparent;
-  width: 25px;
-  height: 25px;
-  position: absolute;
-  top: 4px;
-  left: 0;
-}
-
-.coop-c-form-choice__input + .coop-c-form-choice__label::after {
-  content: "";
-  border: 1px solid #ddd;
-  background: black;
-  width: 15px;
-  height: 15px;
-  position: absolute;
-  top: 9px;
-  left: 5px;
-  opacity: 0;
-}
-
-.coop-c-form-choice__input--checkbox + .coop-c-form-choice__label::before,
-.coop-c-form-choice__input--checkbox + .coop-c-form-choice__label::after {
-  border-radius: 15%;
-}
-.coop-c-form-choice__input--radio-button + .coop-c-form-choice__label::before,
-.coop-c-form-choice__input--radio-button + .coop-c-form-choice__label::after {
-  border-radius: 50%;
-}
-
-.coop-c-form-choice__input--checkbox + .coop-c-form-choice__label::after {
-  background: none;
-  border: solid;
-  border-width: 0 0 3px 3px;
-  transform: rotate(-45deg);
-  border-top-color: transparent;
-  width: 15px;
-  height: 8px;
-  left: 5px;
-  top: 11px;
-}
-
-.coop-c-form-choice__input:checked + .coop-c-form-choice__label::after {
-  opacity: 1;
 }
 
 .coop-c-message {


### PR DESCRIPTION
This PR fully removes legacy CSS from the deprecated **[@coopdigital/component-checkbox](https://www.npmjs.com/package/@coopdigital/component-checkbox)**.

Getting rid of the largely duplicated `.coop-c-form-choice` CSS:

```css
.coop-c-form-choice
.coop-c-form-choice__legend
.coop-c-form-choice__input
.coop-c-form-choice__input--checkbox
.coop-c-form-choice__input--radio-button
.coop-c-form-choice__label
```

Enabling much simpler radio/checkbox HTML:

```html
<form class="coop-form">
  <fieldset class="coop-form__row">
    <legend class="coop-form__label">Type of delivery</legend>
    <div class="coop-form__choice">
      <input type="radio" name="radio" id="radio-1" value="1" class="coop-form__field coop-form__radio">
      <label class="coop-form__label" for="radio-1">Free delivery</label>
    </div>
    <div class="coop-form__choice">
      <input type="radio" name="radio" id="radio-2" value="2" class="coop-form__field coop-form__radio">
      <label class="coop-form__label" for="radio-2">Next day delivery — £4.99</label>
    </div>
  </fieldset>
</form>
```

With customisable dimensions should tap target sizes change in future:

```css
:root {
  --form-choice-width: 25px;
  --form-choice-button-width: 13px;
  --form-choice-stroke-width: 2px;
}
```