### PR TITLE
WB-4045 - Adding BAC brand colour as an option to the hero

### DIFF
--- a/packages/shared-component--hero/contentful/extensions/index.html
+++ b/packages/shared-component--hero/contentful/extensions/index.html
@@ -547,7 +547,18 @@
                       class: 'coop-u-magenta-mid-7-fill',
                       type: 'color',
                       background: '#F690F1'
-                    }
+                    },
+                    {
+                      id: 'color-7d',
+                      name: 'Bereavement Advice Brand',
+                      class: 'coop-u-brand-bac-purple-fill',
+                      fontColour: 'coop-u-white',
+                      clockColour: 'coop-u-white-fill',
+                      linkColour: 'coop-t-link-white',
+                      text: '#fff',
+                      type: 'color',
+                      background: '#674170'
+                    },
                   ]
                 },
                 {


### PR DESCRIPTION
Modifying the hero colour picker to allow the user to select the brand colour for Bereavement Advice Centre. That colour already exists as a class after merging here: https://github.com/coopdigital/coop-frontend/pull/262