### PR TITLE
Fix offers promo tab order and focus outlines

### DIFF
--- a/packages/shared-component--offersPromo/dist/offersPromo.html
+++ b/packages/shared-component--offersPromo/dist/offersPromo.html
@@ -1,5 +1,18 @@
 <article class="coop-c-offerspromo coop-u-brand-membership-pink-lightest-bg">
   <div class="coop-c-offerspromo__inner coop-u-clearfix">
+    <div class="coop-c-offerspromo__content">
+      <a href="https://coop.co.uk/offers" class="coop-c-offerspromo__link" data-contenttype="Card|offerspromo" data-contentparent="" data-linktext="">
+        <header class="coop-c-offerspromo__header">
+            <h3 class="coop-c-offerspromo__title">Join Co-op and get personalised offers like this one every week</h3>
+        </header>
+        <div class="coop-c-offerspromo__body">
+            <p>Get money off products you like to buy or might want to try.</p>
+        </div>
+      </a>
+      <div class="coop-c-offerspromo__terms">
+        <p><a href="https://www.coop.co.uk/terms/digital-offers-terms-and-conditions">Read the terms and conditions</a></p>
+      </div>
+    </div>
     <div class="coop-c-offerspromo__card">
       <a href="https://coop.co.uk/offers" class="coop-c-offerspromo__link coop-u-clearfix" data-contenttype="Card|offerspromo" data-contentparent="" data-linktext="">
         <figure class="coop-c-offerspromo__card-media">
@@ -25,19 +38,6 @@
             <p>When you spend £4 or over</p>
         </header>
       </a>
-    </div>
-    <div class="coop-c-offerspromo__content">
-      <a href="https://coop.co.uk/offers" class="coop-c-offerspromo__link" data-contenttype="Card|offerspromo" data-contentparent="" data-linktext="">
-        <header class="coop-c-offerspromo__header">
-            <h3 class="coop-c-offerspromo__title">Join Co-op and get personalised offers like this one every week</h3>
-        </header>
-        <div class="coop-c-offerspromo__body">
-            <p>Get money off products you like to buy or might want to try.</p>
-        </div>
-      </a>
-      <div class="coop-c-offerspromo__terms">
-        <p><a href="https://www.coop.co.uk/terms/digital-offers-terms-and-conditions">Read the terms and conditions</a></p>
-      </div>
     </div>
   </div>
 </article>

--- a/packages/shared-component--offersPromo/src/offersPromo.html
+++ b/packages/shared-component--offersPromo/src/offersPromo.html
@@ -11,6 +11,28 @@
 
     <div class="coop-c-offerspromo__inner coop-u-clearfix">
 
+      <div class="coop-c-offerspromo__content">
+        <a
+            href="{{offerLink.url}}"
+            class="coop-c-offerspromo__link"
+            data-contenttype="Card|offerspromo"
+            data-contentparent="Deals"
+            data-linktext="{{content.heading}}"
+        >
+          <header class="coop-c-offerspromo__header">
+              <h3 class="coop-c-offerspromo__title">{{content.heading}}</h3>
+          </header>
+          <div class="coop-c-offerspromo__body">
+              <p>{{content.bodyText}}</p>
+          </div>
+        </a>
+        <div class="coop-c-offerspromo__terms">
+          {% with legalLink = cms.get_entry(content.legalLink.sys.id) %}
+              <p><a href="{{legalLink.fields.url.data}}">{{legalLink.fields.title.data}}</a></p>
+          {% endwith %}
+        </div>
+      </div>
+
       <div class="coop-c-offerspromo__card">
         <a
           href="{{offerLink.url}}"
@@ -40,28 +62,6 @@
               </header>
             {% endwith %}
         </a>
-      </div>
-
-      <div class="coop-c-offerspromo__content">
-        <a
-            href="{{offerLink.url}}"
-            class="coop-c-offerspromo__link"
-            data-contenttype="Card|offerspromo"
-            data-contentparent="Deals"
-            data-linktext="{{content.heading}}"
-        >
-          <header class="coop-c-offerspromo__header">
-              <h3 class="coop-c-offerspromo__title">{{content.heading}}</h3>
-          </header>
-          <div class="coop-c-offerspromo__body">
-              <p>{{content.bodyText}}</p>
-          </div>
-        </a>
-        <div class="coop-c-offerspromo__terms">
-          {% with legalLink = cms.get_entry(content.legalLink.sys.id) %}
-              <p><a href="{{legalLink.fields.url.data}}">{{legalLink.fields.title.data}}</a></p>
-          {% endwith %}
-        </div>
       </div>
 
   </div>

--- a/packages/shared-component--offersPromo/src/offersPromo.pcss
+++ b/packages/shared-component--offersPromo/src/offersPromo.pcss
@@ -89,12 +89,7 @@
 }
 
 .coop-c-offerspromo__terms {
-  position: absolute;
-  z-index: 1;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  padding: 0 var(--spacing-16) var(--spacing-24);
+  padding: var(--spacing-8) var(--spacing-16) var(--spacing-24);
 
   & p {
     font-size: var(--type-sp-s);
@@ -159,11 +154,10 @@
 }
 
 .coop-c-offerspromo__content .coop-c-offerspromo__link {
-  padding: var(--spacing-24) var(--spacing-16)
-    calc(var(--spacing-48) + var(--spacing-16));
+  padding: var(--spacing-24) var(--spacing-16) var(--spacing-8);
 
   @media (--mq-large) {
-    min-height: 252px;
+    min-height: 192px;
     padding-left: var(--spacing-24);
     padding-right: var(--spacing-24);
   }


### PR DESCRIPTION
**Tab order** is now consistent across mobile + desktop (£1 offer comes last).

![Tab order on mobile](https://user-images.githubusercontent.com/415517/105733742-c64a7b80-5f29-11eb-9362-c0bc277e1c59.png)

The main link's focus outline no longer overlaps the T&Cs link either:

![Focus outline](https://user-images.githubusercontent.com/415517/105733846-e11cf000-5f29-11eb-8b03-8d94aa65c94d.png)

![Focus outline, terms](https://user-images.githubusercontent.com/415517/105733852-e37f4a00-5f29-11eb-8391-6582aa455a51.png)
