### PR TITLE
Offers promo tag name and :hover/:focus underline

### DIFF
--- a/packages/shared-component--offersPromo/dist/offersPromo.html
+++ b/packages/shared-component--offersPromo/dist/offersPromo.html
@@ -1,4 +1,4 @@
-<article class="coop-c-offerspromo coop-u-brand-membership-pink-lightest-bg">
+<aside class="coop-c-offerspromo coop-u-brand-membership-pink-lightest-bg">
   <div class="coop-c-offerspromo__inner coop-u-clearfix">
     <div class="coop-c-offerspromo__content">
       <a href="https://coop.co.uk/offers" class="coop-c-offerspromo__link" data-contenttype="Card|offerspromo" data-contentparent="" data-linktext="">
@@ -40,4 +40,4 @@
       </a>
     </div>
   </div>
-</article>
+</aside>

--- a/packages/shared-component--offersPromo/src/offersPromo.html
+++ b/packages/shared-component--offersPromo/src/offersPromo.html
@@ -1,7 +1,7 @@
 
 {% import 'macros/elements/images.html' as images %}
 {% macro render(content, cms) -%}
-<article class="coop-c-offerspromo coop-u-brand-membership-pink-lightest-bg">
+<aside class="coop-c-offerspromo coop-u-brand-membership-pink-lightest-bg">
     {% set offerLink = {} %}
     {% with link = cms.get_entry(content.offerLink.sys.id) %}
         {%- set _ = offerLink.update({
@@ -65,5 +65,5 @@
       </div>
 
   </div>
-</article>
+</aside>
 {%- endmacro -%}

--- a/packages/shared-component--offersPromo/src/offersPromo.pcss
+++ b/packages/shared-component--offersPromo/src/offersPromo.pcss
@@ -17,6 +17,15 @@
   text-decoration: none;
   color: inherit;
   border: 0;
+
+  &:hover,
+  &:focus {
+    color: var(--color-text);
+
+    & p {
+      text-decoration: underline;
+    }
+  }
 }
 
 .coop-c-offerspromo__content {
@@ -142,11 +151,6 @@
   background-color: var(--color-white);
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.05);
   border-radius: 4px;
-
-  &:hover,
-  &:focus {
-    color: var(--color-text);
-  }
 
   @media (--mq-large) {
     padding: var(--spacing-16);

--- a/packages/shared-component--offersPromo/src/offersPromo.pcss
+++ b/packages/shared-component--offersPromo/src/offersPromo.pcss
@@ -158,12 +158,11 @@
 }
 
 .coop-c-offerspromo__content .coop-c-offerspromo__link {
-  padding: var(--spacing-24) var(--spacing-16) var(--spacing-8);
+  padding: var(--spacing-16) var(--spacing-16) var(--spacing-8);
 
   @media (--mq-large) {
     min-height: 192px;
-    padding-left: var(--spacing-24);
-    padding-right: var(--spacing-24);
+    padding: var(--spacing-24) var(--spacing-24) var(--spacing-8);
   }
 }
 


### PR DESCRIPTION
Two more acceptance criteria ticked:

1. Use `<aside>` as component tag name
2. Add text underline for **:hover**/**:focus**

![Underline](https://user-images.githubusercontent.com/415517/105827876-6a7c0300-5fba-11eb-9ae7-367dfb94655f.png)
