### PR TITLE
Improve examples

### DIFF
--- a/packages/foundations-forms/src/examples/passwords.html
+++ b/packages/foundations-forms/src/examples/passwords.html
@@ -14,4 +14,11 @@
     <p id="password-confirm-error" class="coop-form__error" hidden></p>
     <input id="password-confirm" class="coop-form__field coop-form__input" type="password" autocomplete="new-password" name="password-confirm">
   </div>
+
+  <div class="coop-form__row">
+    <div class="coop-form__choice">
+      <input id="password-show-hide" type="checkbox" class="coop-form__field coop-form__checkbox">
+      <label for="password-show-hide" class="coop-form__label">Show passwords</label>
+    </div>
+  </div>
 </form>

--- a/packages/foundations-forms/src/examples/passwords.html
+++ b/packages/foundations-forms/src/examples/passwords.html
@@ -6,11 +6,12 @@
   <div class="coop-form__row">
     <label for="password" class="coop-form__label">Password</label>
     <p id="password-error" class="coop-form__error" hidden></p>
-    <input type="password" name="password" id="password" class="coop-form__field coop-form__input">
+    <input id="password" class="coop-form__field coop-form__input" type="password" autocomplete="new-password" name="password">
   </div>
+
   <div class="coop-form__row">
     <label for="password-confirm" class="coop-form__label">Confirm password</label>
     <p id="password-confirm-error" class="coop-form__error" hidden></p>
-    <input type="password" name="passwordConfirm" id="password-confirm" class="coop-form__field coop-form__input">
+    <input id="password-confirm" class="coop-form__field coop-form__input" type="password" autocomplete="new-password" name="password-confirm">
   </div>
 </form>

--- a/packages/foundations-forms/src/examples/passwords.mjs
+++ b/packages/foundations-forms/src/examples/passwords.mjs
@@ -1,0 +1,10 @@
+import { toggleAllMaskUnmask } from '../fields/passwords.mjs';
+
+// Form elements
+const password = document.getElementById('password');
+const passwordConfirm = document.getElementById('password-confirm');
+const passwordToggle = document.getElementById('password-show-hide');
+
+// Unmask password text when ticked
+passwordToggle.addEventListener('click',
+  () => toggleAllMaskUnmask([password, passwordConfirm]));

--- a/packages/foundations-forms/src/examples/text-error.html
+++ b/packages/foundations-forms/src/examples/text-error.html
@@ -6,6 +6,6 @@
   <div class="coop-form__row">
     <label for="full-name-3" class="coop-form__label">Full name</label>
     <p id="full-name-3-error" class="coop-form__error">Enter your full name</p>
-    <input type="text" name="full-name-3" id="full-name-3" class="coop-form__field coop-form__input coop-form__invalid" aria-describedby="full-name-3-error">
+    <input id="full-name-3" class="coop-form__field coop-form__input coop-form__invalid" type="text" autocomplete="name" name="full-name-3" aria-describedby="full-name-3-error">
   </div>
 </form>

--- a/packages/foundations-forms/src/examples/text-hint-error.html
+++ b/packages/foundations-forms/src/examples/text-hint-error.html
@@ -7,6 +7,6 @@
     <label for="full-name-4" class="coop-form__label">Full name</label>
     <p id="full-name-4-hint" class="coop-form__hint">This is an example hint</p>
     <p id="full-name-4-error" class="coop-form__error">Enter your full name</p>
-    <input type="text" name="full-name-4" id="full-name-4" class="coop-form__field coop-form__input coop-form__invalid" aria-describedby="full-name-4-hint full-name-4-error">
+    <input id="full-name-4" class="coop-form__field coop-form__input coop-form__invalid" type="text" autocomplete="name" name="full-name-4" aria-describedby="full-name-4-hint full-name-4-error">
   </div>
 </form>

--- a/packages/foundations-forms/src/examples/text-hint.html
+++ b/packages/foundations-forms/src/examples/text-hint.html
@@ -7,6 +7,6 @@
     <label for="full-name-2" class="coop-form__label">Full name</label>
     <p id="full-name-2-hint" class="coop-form__hint">This is an example hint</p>
     <p id="full-name-2-error" class="coop-form__error" hidden></p>
-    <input type="text" name="full-name-2" id="full-name-2" class="coop-form__field coop-form__input" aria-describedby="full-name-2-hint">
+    <input id="full-name-2" class="coop-form__field coop-form__input coop-form__invalid" type="text" autocomplete="name" name="full-name-2" aria-describedby="full-name-2-hint">
   </div>
 </form>

--- a/packages/foundations-forms/src/examples/text.html
+++ b/packages/foundations-forms/src/examples/text.html
@@ -6,6 +6,6 @@
   <div class="coop-form__row">
     <label for="full-name-1" class="coop-form__label">Full name</label>
     <p id="full-name-1-error" class="coop-form__error" hidden></p>
-    <input type="text" name="full-name-1" id="full-name-1" class="coop-form__field coop-form__input">
+    <input id="full-name-1" class="coop-form__field coop-form__input coop-form__invalid" type="text" autocomplete="name" name="full-name-1">
   </div>
 </form>

--- a/packages/foundations-forms/src/examples/validation-demo.html
+++ b/packages/foundations-forms/src/examples/validation-demo.html
@@ -10,14 +10,14 @@
   <div class="coop-form__row">
     <label class="coop-form__label" for="validation-demo-name">Your full name</label>
     <p id="validation-demo-name-error" class="coop-form__error" hidden></p>
-    <input id="validation-demo-name" class="coop-form__field coop-form__input" type="text" name="validation-demo-name">
+    <input id="validation-demo-name" class="coop-form__field coop-form__input" type="text" autocomplete="name" name="validation-demo-name">
   </div>
 
   <div class="coop-form__row">
     <label class="coop-form__label" for="validation-demo-email">Your email address</label>
     <p id="validation-demo-email-hint" class="coop-form__hint">We’ll only use this to contact you about your will</p>
     <p id="validation-demo-email-error" class="coop-form__error" hidden></p>
-    <input id="validation-demo-email" class="coop-form__field coop-form__input" type="email" name="validation-demo-email" aria-describedby="validation-demo-email-hint">
+    <input id="validation-demo-email" class="coop-form__field coop-form__input" type="email" autocomplete="email" name="validation-demo-email" aria-describedby="validation-demo-email-hint">
   </div>
 
   <div class="coop-form__row">


### PR DESCRIPTION
To adhere to **WCAG 2.2 "Success Criterion 1.3.5 Identify Input Purpose"** I've added [`autocomplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attributes to all the form HTML examples, more info here: https://www.w3.org/TR/WCAG22/#input-purposes

```html
<!-- Input -->
<form id="text" class="coop-form" novalidate>
  <h3>Input</h3>

  <div class="coop-form__row">
    <label for="full-name-1" class="coop-form__label">Full name</label>
    <p id="full-name-1-error" class="coop-form__error" hidden></p>
    <input id="full-name-1" class="coop-form__field coop-form__input coop-form__invalid" type="text" autocomplete="name" name="full-name-1">
  </div>
</form>
```

Notice `autocomplete="name"` on the input.

The password example is no longer missing the JS show/hide toggle either.