### PR TITLE
Wire up password show/hide example

### DIFF
--- a/design-system/src/_js/examples.mjs
+++ b/design-system/src/_js/examples.mjs
@@ -2,3 +2,8 @@
 if (document.getElementById('validation-demo')) {
   (async () => import('./examples/form-validation.mjs'))();
 }
+
+// Example unmask password toggle
+if (document.getElementById('password')) {
+  (async () => import('./examples/passwords.mjs'))();
+}

--- a/design-system/src/_js/examples/passwords.mjs
+++ b/design-system/src/_js/examples/passwords.mjs
@@ -1,0 +1,1 @@
+import '@coopdigital/foundations-forms/src/examples/passwords.mjs';

--- a/design-system/src/pattern-library/examples/components/passwords.html
+++ b/design-system/src/pattern-library/examples/components/passwords.html
@@ -1,0 +1,9 @@
+---
+layout: blank
+id: examples
+---
+<div class="coop-l-grid">
+    <div class="coop-l-grid__item coop-l-grid__item--large-4 coop-l-grid__item--medium-6 coop-u-margin-t-64">
+        {% include pattern-library/components/foundations-forms/src/examples/passwords.html %}
+    </div>
+</div>

--- a/design-system/src/pattern-library/examples/index.html
+++ b/design-system/src/pattern-library/examples/index.html
@@ -45,7 +45,7 @@ id: pattern-library
                 </ul>
             </div>
             <div class="coop-l-grid__item coop-l-grid__item--large-4">
-                <h2>Components not yet documented</h2> 
+                <h2>Components not yet documented</h2>
                 <ul class="coop-u-margin-resp-b-64-32">
                     <li><a href="components/signpost-list.html">Signpost list</a></li>
                     <li><a href="components/offers-promo.html">Offers promo</a></li>
@@ -57,6 +57,7 @@ id: pattern-library
                     <li><a href="components/totaliser.html">Money raised totaliser</a></li>
                     <li><a href="components/list-of-links.html">List of links</a></li>
                     <li><a href="components/postcode-search.html">Postcode search</a></li>
+                    <li><a href="components/passwords.html">Passwords</a></li>
                 </ul>
             </div>
             <div class="coop-l-grid__item coop-l-grid__item--large-4">


### PR DESCRIPTION
This PR enables the "show/hide" password toggle.

```js
// Unmask password text when ticked
passwordToggle.addEventListener('click',
  () => toggleAllMaskUnmask([password, passwordConfirm]));
```

It was already merged in https://github.com/coopdigital/coop-frontend/pull/303 but adds a working example as shown:

![Password toggle](https://user-images.githubusercontent.com/415517/107972921-743aca00-6fac-11eb-8160-85a95455868a.png)