### PR TITLE
WB-4928 Changed link to check classNames on linkEntry

### DIFF
--- a/packages/shared-component--link/src/link.html
+++ b/packages/shared-component--link/src/link.html
@@ -15,18 +15,18 @@
 		{%- endif -%}
     
     {# set class names based on link style data #}
-    {% if content.data.fields and content.data.fields.linkStyle %}
+    {% if linkEntry.data.fields and linkEntry.data.fields.linkStyle %}
       {%- set classNames = 'coop-btn' -%}
 
-      {%- if content.data.fields.linkStyle == 'Link - black' -%}
+      {%- if linkEntry.data.fields.linkStyle == 'Link - black' -%}
         {%- set classNames = 'coop-t-link-black' -%}
-      {%- elif content.data.fields.linkStyle == 'Link - white' -%}
+      {%- elif linkEntry.data.fields.linkStyle == 'Link - white' -%}
         {%- set classNames = 'coop-t-link-white' -%}
-      {%- elif content.data.fields.linkStyle == 'Button - primary' -%}
+      {%- elif linkEntry.data.fields.linkStyle == 'Button - primary' -%}
         {%- set classNames = classNames ~ ' coop-btn--primary ' -%}
-      {%- elif content.data.fields.linkStyle == 'Button - secondary' -%}
+      {%- elif linkEntry.data.fields.linkStyle == 'Button - secondary' -%}
         {%- set classNames = classNames ~ ' coop-btn--blue ' -%}
-      {%- elif content.data.fields.linkStyle == 'Button - white' -%}
+      {%- elif linkEntry.data.fields.linkStyle == 'Button - white' -%}
         {%- set classNames = classNames ~ ' coop-btn--white ' -%}
       {%- endif -%}
     {%- endif -%}


### PR DESCRIPTION
The parent component of a link only sees basic data about a link, ID, type, etc

We use this ID to get all data about a link within the link component so we know what to render.

The previous version of the link incorrectly looked at the basic content passed into the macro which prevented any links from being anything other than a generic blue link.

This update changes this so we now look at the full link entry data so we know what type of link style we need to show.