### PR TITLE
WB-5016 Updated notification to take config and an ID property

### DIFF
--- a/packages/shared-component--notification/readme.md
+++ b/packages/shared-component--notification/readme.md
@@ -9,3 +9,12 @@ The contentful properties available are:
 - Body text
 - Link (reference to another link)
 - Type of notification (alert or notification)
+
+#
+## Config options
+
+```TypeScript
+{
+  "id": String - required
+}
+```

--- a/packages/shared-component--notification/src/notification.html
+++ b/packages/shared-component--notification/src/notification.html
@@ -1,8 +1,8 @@
 {%- import '/shared-component--link/src/link.html' as link -%}
 
-{%- macro render(content, cms) -%}
+{%- macro render(config, cms) -%}
   
-  {%- set notificationData = cms.get_entry(content.data.sys.id) -%}
+  {%- set notificationData = cms.get_entry(config.id) -%}
   {%- set role = notificationData.fields.typeOfNotification.data -%}
   {%- set notificationTypeClass = '' -%}
 


### PR DESCRIPTION
The format of a component's data depends on where the component lives, so instead of relying on the component to handle every scenario we just pass in the ID as part of the config options.

