### PR TITLE
WB-4733 update signpost template to handle intenalLink urls with anchors

### DIFF
--- a/packages/shared-component--signpost/src/signpost.html
+++ b/packages/shared-component--signpost/src/signpost.html
@@ -1,28 +1,43 @@
 {% macro render(content, cms, config) %}
+
   <div class="coop-c-signpost-list__item coop-c-signpost">
     {% if content.fields.link and content.fields.link.sys.id %}
       {% with entryLink = cms.get_entry(content.fields.link.sys.id) %}
 
         {% if entryLink.type == 'internalLink' %}
+
           {% if entryLink.data.fields.page %}
             {% with internalLink = cms.get_entry(entryLink.data.fields.page.sys.id) %}
-              <a
-                href="{{tenant_url_path}}{{ internalLink.full_url_path }}"
-                class="coop-c-signpost__link"
-                data-contenttype="Signpost"
-                data-contentparent="{{ config.contentParent|safe }}"
-                data-linktext="{{ content.fields.title|safe }}"
-              >
+
+                {# Append full path if not home page #}
+                {%- if internalLink.full_url_path == '/' -%}
+                  {%- set href = tenant_url_path -%}
+                {%- else -%}
+                  {%- set href = tenant_url_path + internalLink.full_url_path -%}
+                {%- endif -%}
+
+                {# Strip trailing slash #}
+
+                {%- set href = href.rstrip("/") -%}
+
+                {# Append anchor if available #}
+                {%- if entryLink.fields.anchor and entryLink.fields.anchor.data -%}
+                  {%- set href = href + "#" + entryLink.fields.anchor.data -%}
+                {%- endif -%}
+
+              <a href="{{href}}"
+                 class="coop-c-signpost__link"
+                 data-contenttype="Signpost"
+                 data-contentparent="{{ config.contentParent|safe }}"
+                data-linktext="{{ content.fields.title|safe }}">
             {% endwith %}
           {% endif %}
         {% elif entryLink.fields.url.data %}
-          <a
-            href="{{ entryLink.fields.url.data }}"
-            class="coop-c-signpost__link"
-            data-contenttype="Signpost"
-            data-contentparent="{{ config.contentParent|safe }}"
-            data-linktext="{{ content.fields.title|safe }}"
-          >
+          <a href="{{ entryLink.fields.url.data }}"
+             class="coop-c-signpost__link"
+             data-contenttype="Signpost"
+             data-contentparent="{{ config.contentParent|safe }}"
+             data-linktext="{{ content.fields.title|safe }}">
         {% endif %}
       {% endwith %}
     {% endif %}
@@ -31,38 +46,38 @@
       {% with imageEntry = cms.get_asset(content.fields.image.sys.id) %}
         <figure class="coop-c-signpost__media">
           <picture class="coop-c-signpost__image">
-            
+
             <source media="(min-width: 48em)"
                     srcset="{{ imageEntry.fields.file.url }}?fm=webp&amp;fit=thumb&amp;q=60&amp;w=360&amp;h=203 1x,
                               {{ imageEntry.fields.file.url }}?fm=webp&amp;fit=thumb&amp;q=60&amp;w={{ 360 * 2 }}&amp;h={{ 203 * 2 }} 2x"
                     type="image/webp" />
-            
+
             <source media="(min-width: 37.5em)"
                     srcset="{{ imageEntry.fields.file.url }}?fm=webp&amp;fit=thumb&amp;q=60&amp;w=751&amp;h=423 1x,
                               {{ imageEntry.fields.file.url }}?fm=webp&amp;fit=thumb&amp;q=60&amp;w={{ 751 * 2 }}&amp;h={{ 423 * 2 }} 2x"
                     type="image/webp" />
-            
+
             <source media="(min-width: 25.9375em)"
                     srcset="{{ imageEntry.fields.file.url }}?fm=webp&amp;fit=thumb&amp;q=60&amp;w=583&amp;h=329 1x,
                               {{ imageEntry.fields.file.url }}?fm=webp&amp;fit=thumb&amp;q=60&amp;w={{ 583 * 2 }}&amp;h={{ 329 * 2 }} 2x"
                     type="image/webp" />
 
-            
+
             <source media="(min-width: 48em)"
                     srcset="{{ imageEntry.fields.file.url }}?fm=jpg&amp;fit=thumb&amp;fl=progressive&amp;q=60&amp;w=360&amp;h=203 1x,
                               {{ imageEntry.fields.file.url }}?fm=jpg&amp;fit=thumb&amp;fl=progressive&amp;q=60&amp;w={{ 360 * 2 }}&amp;h={{ 203 * 2 }} 2x"
                     type="image/jpeg" />
-            
+
             <source media="(min-width: 37.5em)"
                     srcset="{{ imageEntry.fields.file.url }}?fm=jpg&amp;fit=thumb&amp;fl=progressive&amp;q=60&amp;w=751&amp;h=423 1x,
                               {{ imageEntry.fields.file.url }}?fm=jpg&amp;fit=thumb&amp;fl=progressive&amp;q=60&amp;w={{ 751 * 2 }}&amp;h={{ 423 * 2 }} 2x"
                     type="image/jpeg" />
-            
+
             <source media="(min-width: 25.9375em)"
                     srcset="{{ imageEntry.fields.file.url }}?fm=jpg&amp;fit=thumb&amp;fl=progressive&amp;q=60&amp;w=583&amp;h=329 1x,
                               {{ imageEntry.fields.file.url }}?fm=jpg&amp;fit=thumb&amp;fl=progressive&amp;q=60&amp;w={{ 583 * 2 }}&amp;h={{ 329 * 2 }} 2x"
                     type="image/jpeg"/>
-            
+
             <img src="{{ imageEntry.fields.file.url }}?fm=jpg&amp;fit=thumb&amp;q=60&amp;w=751&amp;h=423"
                   alt="{% if imageEntry.fields.description %}{{ imageEntry.fields.description }}{% else %}{{ imageEntry.fields.title }}{% endif %}">
           </picture>
@@ -89,7 +104,7 @@
       {% endif %}
 
       <h3 class="coop-c-signpost__title">
-        {{ content.fields.title }}
+       {{ content.fields.title }}
       </h3>
       <span class="coop-c-signpost__icon" aria-hidden="true">
         <svg class="coop-c-signpost__icon__svg" viewBox="0 0 16 29">


### PR DESCRIPTION
Add logic to shared cms component signpost to handle internalLink contentType anchor field values.

Anchors were introduced to shared cms component internalLink contentTypes.  

This MR allows the cms signpost to carry those link url anchors   