### PR TITLE
feat: add InputText component and update tests to remove snapshots

### DIFF
--- a/packages/react-ui/src/InputText/__tests__/InputText.test.js
+++ b/packages/react-ui/src/InputText/__tests__/InputText.test.js
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+
+import InputText from "../src/index";
+
+afterEach(cleanup);
+
+describe("InputText", () => {
+  it("should render correctly", () => {
+    const { getByLabelText, container } = render(
+      <InputText id="test" name="test" label="default label" />
+    );
+    expect(getByLabelText("default label")).toBeInTheDocument();
+  });
+
+  it("should support all variants", () => {
+    // const variantMap = new Map([ ['withLabel', {}], ['withHint', {}], ['withLabelAndHint', {}]  ])
+    const Variants = () => (
+      <div>
+        <InputText
+          data-testid="withLabel"
+          id="withLabel"
+          name="withLabel"
+          label="Input with label"
+        />
+        <InputText
+          data-testid="withHint"
+          id="withHint"
+          name="withHint"
+          hint="Input with hint"
+        />
+        <InputText
+          data-testid="withLabelAndHint"
+          id="withLabelAndHint"
+          name="withLabelAndHint"
+          label="Input with label and hint"
+          hint="Input with label and hint"
+        />
+      </div>
+    );
+
+    const { container, getByTestId, getByLabelText } = render(<Variants />);
+
+    expect(container.getElementsByTagName("input").length).toBe(3);
+
+    expect(getByTestId("withHint")).toHaveAccessibleDescription(
+      "Input with hint"
+    );
+    expect(getByTestId("withLabelAndHint")).toHaveAccessibleDescription(
+      "Input with label and hint"
+    );
+  });
+
+  it("should support all variants with error", () => {
+    const VariantsWithError = () => (
+      <div>
+        <InputText
+          id="withLabelAndError"
+          data-testid="withLabelAndError"
+          name="withLabelAndError"
+          label="Input with label"
+          errorMsg="Error message"
+          hasError
+        />
+        <InputText
+          id="withHintAndError"
+          data-testid="withHintAndError"
+          name="withHintAndError"
+          hint="Input with hint"
+          errorMsg="Error message"
+          hasError
+        />
+        <InputText
+          id="withLabelHintAndError"
+          data-testid="withLabelHintAndError"
+          name="withLabelHintAndError"
+          label="Input with label and hint"
+          hint="Input with label and hint"
+          errorMsg="Error message"
+          hasError
+        />
+      </div>
+    );
+
+    const { container } = render(<VariantsWithError />);
+    const errorMessages = container.getElementsByClassName("coop-form__error");
+
+    const errorInputs = container.getElementsByClassName("coop-form__invalid");
+    expect(errorInputs.length).toBe(3);
+
+    expect(errorMessages.length).toBe(3);
+    for (let i = 0; i < errorMessages.length; i++) {
+      expect(errorMessages[i]).toHaveTextContent("Error message");
+    }
+  });
+
+  it("should allow percentage set widths based on the parent container width", () => {
+    const width = 20;
+    const { getByLabelText, container } = render(
+      <InputText id="test" name="test" label="with set width" width={width} />
+    );
+
+    expect(getByLabelText("with set width")).toHaveClass(
+      `coop-form__input--width-${width}`
+    );
+  });
+
+  it("should be hidden when the prop `type` is hidden", () => {
+    const { container, getByPlaceholderText } = render(
+      <InputText
+        placeholder="input placeholder hidden"
+        type="hidden"
+        id="test"
+        name="test"
+        label="is hidden"
+      />
+    );
+
+    expect(getByPlaceholderText("input placeholder hidden")).not.toBeVisible();
+  });
+});

--- a/packages/react-ui/src/InputText/src/InputText.jsx
+++ b/packages/react-ui/src/InputText/src/InputText.jsx
@@ -1,0 +1,106 @@
+import React, { forwardRef } from "react";
+import PropTypes from "prop-types";
+import classNames from "../../utils/classNames";
+
+const InputText = forwardRef(
+  (
+    {
+      id,
+      name,
+      type,
+      className,
+      label,
+      hint,
+      hasError,
+      errorMsg,
+      disabled,
+      placeholder,
+      width,
+      ...props
+    },
+    ref
+  ) => {
+    const hintId = `${id}-hint`;
+    const errorId = `${id}-error`;
+    const classes = classNames("coop-form__field coop-form__input", [
+      hasError && "coop-form__invalid",
+      width && `coop-form__input--width-${width}`,
+      className,
+    ]);
+
+    const ariaDescribedBy = [];
+    if (hint) ariaDescribedBy.push(hintId);
+    if (hasError) ariaDescribedBy.push(errorId);
+
+    return (
+      <div className="coop-form__row">
+        {label && (
+          <label htmlFor={id} className="coop-form__label">
+            {label}
+          </label>
+        )}
+        {hint && (
+          <p id={`${id}-hint`} className="coop-form__hint">
+            {hint}
+          </p>
+        )}
+        {hasError && (
+          <p id={`${id}-error`} className="coop-form__error">
+            {errorMsg}
+          </p>
+        )}
+        <input
+          type={type}
+          name={name}
+          id={id}
+          className={classes}
+          aria-describedby={ariaDescribedBy && ariaDescribedBy.join(" ")}
+          disabled={disabled}
+          placeholder={placeholder}
+          ref={ref}
+          {...props}
+        />
+      </div>
+    );
+  }
+);
+
+InputText.defaultProps = {
+  type: "text",
+  disabled: false,
+  hasError: false,
+  className: null,
+  hint: null,
+  label: null,
+  errorMsg: null,
+  placeholder: null,
+  width: null,
+};
+
+InputText.propTypes = {
+  /** id - (required) can be used for identifying the specific form element for labels and targeting values for form submission. */
+  id: PropTypes.string.isRequired,
+  /** name - (required) can be used for identifying the specific form element for labels and targeting values for form submission. */
+  name: PropTypes.string.isRequired,
+  /** type - can be one of either `text` or `hidden`*/
+  type: PropTypes.oneOf(["text", "hidden"]),
+  /** className - optional and is used to add more styling to the input if required in your project.*/
+  className: PropTypes.string,
+  /** label - It's helpful fot all form inputs require a label to describe the what the input does. */
+  label: PropTypes.string,
+  /** hint - (optional) can be used to help guide users in filling in areas of a form. */
+  hint: PropTypes.string,
+  /** hasError - (optional/state managed?) this would trigger on the element when an error state occurs.
+   * Requires state management to set this */
+  hasError: PropTypes.bool,
+  /** errorMsg - (optional) shows the user an error message when an error occurs in filling out a form or form processing.*/
+  errorMsg: PropTypes.string,
+  /** disabled - is the input disabled by default or not.*/
+  disabled: PropTypes.bool,
+  /** placeholder - a string of text used as a placeholder for the input.*/
+  placeholder: PropTypes.string,
+  /** width - used to set the width of the input in a form.  Width is based on percentage of the inputs parent container.*/
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+export default InputText;

--- a/packages/react-ui/src/InputText/src/InputText.stories.js
+++ b/packages/react-ui/src/InputText/src/InputText.stories.js
@@ -1,0 +1,68 @@
+import React from "react";
+import InputText from "./InputText";
+
+// export default {
+//   title: "Base/InputText",
+//   component: InputText,
+// };
+
+export const Basic = (args) => <InputText {...args} />;
+Basic.args = {
+  id: "input",
+  name: "input",
+};
+
+export const All = () => (
+  <>
+    <InputText id="label" name="label" />
+    <InputText id="label" name="label" label="Input with label" />
+    <InputText
+      id="label"
+      name="label"
+      label="Input with label and set width"
+      width={10}
+    />
+    <InputText id="label" name="label" hint="Input with hint" />
+    <InputText
+      id="label"
+      name="label"
+      label="Input with label and hint"
+      hint="Input with label and hint"
+    />
+  </>
+);
+
+export const WithError = () => (
+  <>
+    <InputText
+      id="label"
+      name="label"
+      label="Input with label"
+      errorMsg="Error message"
+      hasError
+    />
+    <InputText
+      id="label"
+      name="label"
+      label="Input with label and set width"
+      errorMsg="Error message"
+      hasError
+      width={10}
+    />
+    <InputText
+      id="label"
+      name="label"
+      hint="Input with hint"
+      errorMsg="Error message"
+      hasError
+    />
+    <InputText
+      id="label"
+      name="label"
+      label="Input with label and hint"
+      hint="Input with label and hint"
+      errorMsg="Error message"
+      hasError
+    />
+  </>
+);

--- a/packages/react-ui/src/InputText/src/InputText.stories.mdx
+++ b/packages/react-ui/src/InputText/src/InputText.stories.mdx
@@ -1,0 +1,141 @@
+import {
+  ArgsTable,
+  Meta,
+  Story,
+  Canvas,
+  Source,
+  Preview,
+} from "@storybook/addon-docs/blocks";
+import InputText from "./InputText";
+
+<!-- Add base Meta for each story,
+     meta like args can be overridden at story level if required -->
+<Meta title="Elements/InputText" component={InputText} />
+
+<!--- Start content -->
+# InputText
+Intro to InputText.
+
+## Usage
+Usage of radio form controls
+
+## Default InputText example
+A test canvas to show the component and it's underlying code.
+A canvas can include stories or just plain components like the one below.
+<Canvas>
+  <InputText label="A basic select" id="id" name="name" />
+</Canvas>
+
+## Props
+<p>The InputText takes the props from the table below.</p>
+<ArgsTable components={{ InputText: InputText }} />
+
+<hr />
+
+## Stories for the InputText component
+
+We can keep component stories at the bottom of the documentation pages, for better doc readability.
+
+### Basic InputText story
+This select includes the required props `id` and `name` as well as a `label` and `options` props.
+<Canvas>
+  <Story name="Basic InputText"
+    args={{
+      id: "basic",
+      name: "basic",
+      label: "Input with label",
+    }}>
+    {(args) => <InputText {...args} />}
+  </Story>
+</Canvas>
+
+### InputText with width story
+A select with width set to `10` which equals a width of 10% in it's container.
+<Canvas>
+  <Story name="With width"
+    args={{
+      id: "withWidth",
+      name: "withWidth",
+      width: 10,
+    }}>
+    {(args) => <InputText {...args} />}
+  </Story>
+</Canvas>
+
+### InputText with placeholder
+<Canvas>
+  <Story name="With placeholder"
+    args={{
+      id: "withplaceholder",
+      name: "withplaceholder",
+      placeholder: "Placeholder",
+    }}>
+    {(args) => <InputText {...args} />}
+  </Story>
+</Canvas>
+
+### InputText with hint
+<Canvas>
+  <Story name="With hint"
+    args={{
+      id: "withhint",
+      name: "withhint",
+      hint: "Hint to help guide the user",
+    }}>
+    {(args) => <InputText {...args} />}
+  </Story>
+</Canvas>
+
+### InputText with label and hint
+<Canvas>
+  <Story name="With hint and label"
+    args={{
+      id: "withhintandlabel",
+      name: "withhintandlabel",
+      label: "Text input label",
+      hint: "Hint to help guide the user",
+    }}>
+    {(args) => <InputText {...args} />}
+  </Story>
+</Canvas>
+
+### InputText disabled
+<Canvas>
+  <Story name="InputText disabled"
+    args={{
+      id: "basic-disabled",
+      name: "basic-disabled",
+      label: "Input disabled with label",
+      disabled: true,
+    }}>
+    {(args) => <InputText {...args} />}
+  </Story>
+</Canvas>
+
+### InputText with errors
+<Canvas>
+  <Story name="With errors"
+    args={{
+      id: "withhint",
+      name: "withhint",
+      hasError: true,
+      errorMsg: "Error message",
+    }}>
+    {(args) => <InputText {...args} />}
+  </Story>
+</Canvas>
+
+### InputText with errors, label and hint
+<Canvas>
+  <Story name="With errors, label and hint"
+    args={{
+      id: "withhint",
+      name: "withhint",
+      label: "Text input label",
+      hint: "hint text to help guide users",
+      hasError: true,
+      errorMsg: "Error message",
+    }}>
+    {(args) => <InputText {...args} />}
+  </Story>
+</Canvas>

--- a/packages/react-ui/src/InputText/src/index.js
+++ b/packages/react-ui/src/InputText/src/index.js
@@ -1,0 +1,3 @@
+import InputText from "./InputText";
+
+export default InputText;


### PR DESCRIPTION
resolves #382 

- Moved InputText over from coop-ds-storybook.
- Moved files for component and stories under `src` directory within the component directory.
- Updated tests to replace enzyme and react test renderer, with react testing library and jest-dom.  
- Replaced snapshot testing with more DOM related checks against the component. 