### PR TITLE
updated background URI to better quality banner image on contentful

### DIFF
--- a/packages/shared-component--postcode/src/postcode.pcss
+++ b/packages/shared-component--postcode/src/postcode.pcss
@@ -1,7 +1,7 @@
 @import "@coopdigital/foundations-vars";
 
 .coop-c-postcode {
-  background: url("https://images.ctfassets.net/6jpeaipefazr/2oHuFOFgaPu540mDLZVRyC/bddf4e0ce16e2fdb01d27738df74627f/food-instore-2.jpeg?fm=jpg&fl=progressive&q=80&h=300&fit=crop")
+  background: url("https://images.ctfassets.net/6jpeaipefazr/5XKCMyduATrYj5jHNU6e31/0fc41bb899ad1dc2ebeb68d2097fcf18/food-instore-3.jpg?fm=jpg&fl=progressive&q=100&h=300&fit=crop")
     no-repeat 0 -10px;
   background-color: var(--color-grey-neutral-warm);
   background-size: contain;


### PR DESCRIPTION
please see ticket: https://co-op-digital.atlassian.net/jira/software/projects/FCED/boards/458?selectedIssue=FCED-19

the background image in the postcode component is pixelated. Have replaced the original image on contentful with a better quality original. Also set to q=100 query parameter to improve the quality.