### PR TITLE
Add autocomplete attribute to Postcode component's postcode input

### DIFF
--- a/packages/shared-component--postcode/dist/postcode.html
+++ b/packages/shared-component--postcode/dist/postcode.html
@@ -9,6 +9,7 @@
           <input name="coop-c-postcode__search"
                   id="coop-c-postcode__search"
                   type="search"
+                  autocomplete="postal-code"
                   placeholder="For example, M60 0AG"
                   data-utm-source=""
                   data-utm-medium=""

--- a/packages/shared-component--postcode/src/postcode.html
+++ b/packages/shared-component--postcode/src/postcode.html
@@ -10,6 +10,7 @@
           <input name="coop-c-postcode__search"
                   id="coop-c-postcode__search"
                   type="search"
+                  autocomplete="postal-code"
                   placeholder="{{content.formPlaceholder}}"
                   data-utm-source="{% if 'utmSource' in content %}{{content.utmSource }}{% endif %}"
                   data-utm-medium="{% if 'utmMedium' in content %}{{content.utmMedium}}{% endif %}"


### PR DESCRIPTION
I noticed we aren't providing an example of using an `autocomplete` attribute on the [Postcode search](https://coop-design-system.herokuapp.com/pattern-library/examples/components/postcode-search.html) component.

This is a super small change (my first Github PR since joining the Co-op last week 🥳) but using `autocomplete` [helps meet](https://www.w3.org/WAI/WCAG21/Techniques/html/H98) WCAG [1.3.5: Identify Input Purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html) and it reduces friction for customers too.

Before:
![image](https://user-images.githubusercontent.com/6339853/139029711-162f8107-2ef7-4911-8081-0a1833b4e143.png)

After:
![image](https://user-images.githubusercontent.com/6339853/139029684-732ca299-87e7-474f-8e1c-8aed1f6d53da.png)

I've made the markup changes but not sure what needs to happen next (after reviewing) to release and deploy the change.