### PR TITLE
feat: add autocapitalize to postcode inputs to encourage all caps entry on virtual keyboards

### DIFF
--- a/packages/shared-component--postcode/dist/postcode.html
+++ b/packages/shared-component--postcode/dist/postcode.html
@@ -10,6 +10,7 @@
                   id="coop-c-postcode__search"
                   type="search"
                   autocomplete="postal-code"
+                  autocapitalize="characters"
                   placeholder="For example, M60 0AG"
                   data-utm-source=""
                   data-utm-medium=""

--- a/packages/shared-component--postcode/src/postcode.html
+++ b/packages/shared-component--postcode/src/postcode.html
@@ -11,6 +11,7 @@
                   id="coop-c-postcode__search"
                   type="search"
                   autocomplete="postal-code"
+                  autocapitalize="characters"
                   placeholder="{{content.formPlaceholder}}"
                   data-utm-source="{% if 'utmSource' in content %}{{content.utmSource }}{% endif %}"
                   data-utm-medium="{% if 'utmMedium' in content %}{{content.utmMedium}}{% endif %}"


### PR DESCRIPTION
This is a very small change to the example markup for a postcode entry component that uses the `autocapitalize` HTML attribute to instruct virtual keyboards (e.g. on mobile) to default to using 'ALL CAPS' entry rather than 'Sentence case' entry. We recently added this to https://shop.coop.co.uk. 

Postcode input is specifically mentioned as a good use case in [this Google Developers blog introducing the attribute](https://developers.google.com/web/updates/2015/04/autocapitalize):

> Use `autocapitalization=characters` if you are expecting:
> - US states
> - UK postal codes

There is a typo in that blog post quotation above where the author has called the attribute `autocapitalization` instead of `autocapitalize`, but [the attribute name is definitely `autocapitalize`](https://html.spec.whatwg.org/multipage/interaction.html#autocapitalization). 