### PR TITLE
Build: Fix version workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "build:js": "lerna exec --scope @coopdigital/foundations-* --scope @coopdigital/shared-component-* --stream -- 'babel src/ --out-dir dist/ --source-maps --config-file ../../babel.config.js'",
     "build:foundations": "lerna run --stream --scope @coopdigital/foundations build",
     "build:component": "lerna exec --scope @coopdigital/component-* 'rollup --config ../../build/rollup/index.js'",
-    "package:version": "lerna version --conventional-commits --yes",
+    "package:version": "lerna version --conventional-commits --yes --amend",
     "publish": "lerna publish from-package --yes --no-verify-access"
   },
   "heroku-run-build-script": true,

--- a/packages/shared-component--postcode/package.json
+++ b/packages/shared-component--postcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coopdigital/shared-component--postcode",
-  "version": "2.2.21",
+  "version": "2.3.0",
   "description": "Co-op Shared Component: Postcode",
   "main": "dist/postcode.css",
   "style": "src/postcode.pcss",


### PR DESCRIPTION
Adding `--amend` to the versioning script to commit the version bumps into the previous commit rather than creating a new one. 

Currently the CI pipeline can't push as we now protect the `master` branch.