### PR TITLE
Wip formatting changes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "printWidth": 100
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,23 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+        'wip',
+      ],
+    ],
+  },
+};

--- a/packages/component-card/src/card.pcss
+++ b/packages/component-card/src/card.pcss
@@ -101,9 +101,7 @@
   }
 }
 
-.coop-c-editorialcard--horizontal
-  .coop-c-editorialcard__media
-  + .coop-c-editorialcard__content {
+.coop-c-editorialcard--horizontal .coop-c-editorialcard__media + .coop-c-editorialcard__content {
   @media (--mq-medium) {
     padding-left: 1.5rem;
   }

--- a/packages/config-eslint/index.js
+++ b/packages/config-eslint/index.js
@@ -10,6 +10,22 @@ module.exports = {
   },
   plugins: ['jest'],
   rules: {
+    'no-plusplus': [
+      1,
+      {
+        allowForLoopAfterthoughts: true,
+      },
+    ],
+    'max-len': [
+      'warn',
+      {
+        ignoreUrls: true,
+        ignoreStrings: true,
+        ignoreComments: true,
+        ignoreTemplateLiterals: true,
+        code: 100,
+      },
+    ],
     'arrow-body-style': 'off',
     'import/extensions': [
       'error',

--- a/packages/foundations-forms/src/forms.pcss
+++ b/packages/foundations-forms/src/forms.pcss
@@ -9,12 +9,12 @@
 
   --form-choice-button-width: 13px;
   --form-choice-button-offset-top-s: calc(
-    var(--form-choice-offset-top-s) +
-      (var(--form-choice-width) - var(--form-choice-button-width)) / 2
+    var(--form-choice-offset-top-s) + (var(--form-choice-width) - var(--form-choice-button-width)) /
+      2
   );
   --form-choice-button-offset-top-l: calc(
-    var(--form-choice-offset-top-l) +
-      (var(--form-choice-width) - var(--form-choice-button-width)) / 2
+    var(--form-choice-offset-top-l) + (var(--form-choice-width) - var(--form-choice-button-width)) /
+      2
   );
 
   --form-choice-stroke-width: 2px;
@@ -310,8 +310,7 @@ input[type="radio"],
   margin: 0;
   padding-right: var(--spacing-16);
   padding-left: calc(
-    var(--form-choice-width) - var(--form-choice-stroke-width) +
-      var(--spacing-16)
+    var(--form-choice-width) - var(--form-choice-stroke-width) + var(--spacing-16)
   );
   cursor: pointer;
   touch-action: manipulation;
@@ -320,8 +319,7 @@ input[type="radio"],
 .coop-form__choice .coop-form__hint {
   margin-top: 0;
   padding-left: calc(
-    var(--form-choice-width) - var(--form-choice-stroke-width) +
-      var(--spacing-16)
+    var(--form-choice-width) - var(--form-choice-stroke-width) + var(--spacing-16)
   );
 }
 

--- a/packages/foundations/src/vars/colors-membership.pcss
+++ b/packages/foundations/src/vars/colors-membership.pcss
@@ -8,24 +8,12 @@
   --color-brand-membership-purple-light-8: #b2aece;
   --color-brand-membership-purple-light-9: #d3d1e4;
   --color-brand-membership-purple-light-10: #eae8f4;
-  --color-brand-membership-purple-dark: var(
-    --color-brand-membership-purple-dark-3
-  );
-  --color-brand-membership-purple-mid: var(
-    --color-brand-membership-purple-mid-5
-  );
-  --color-brand-membership-purple-bright: var(
-    --color-brand-membership-purple-mid-6
-  );
-  --color-brand-membership-purple-light: var(
-    --color-brand-membership-purple-light-8
-  );
-  --color-brand-membership-purple-lighter: var(
-    --color-brand-membership-purple-light-9
-  );
-  --color-brand-membership-purple-lightest: var(
-    --color-brand-membership-purple-light-10
-  );
+  --color-brand-membership-purple-dark: var(--color-brand-membership-purple-dark-3);
+  --color-brand-membership-purple-mid: var(--color-brand-membership-purple-mid-5);
+  --color-brand-membership-purple-bright: var(--color-brand-membership-purple-mid-6);
+  --color-brand-membership-purple-light: var(--color-brand-membership-purple-light-8);
+  --color-brand-membership-purple-lighter: var(--color-brand-membership-purple-light-9);
+  --color-brand-membership-purple-lightest: var(--color-brand-membership-purple-light-10);
 
   /* Membership (Lilac) */
   --color-brand-membership-lilac-dark-1: #52355e;
@@ -36,22 +24,12 @@
   --color-brand-membership-lilac-light-8: #bba2c6;
   --color-brand-membership-lilac-light-9: #ccbad4;
   --color-brand-membership-lilac-light-10: #e6dde9;
-  --color-brand-membership-lilac-dark: var(
-    --color-brand-membership-lilac-dark-3
-  );
+  --color-brand-membership-lilac-dark: var(--color-brand-membership-lilac-dark-3);
   --color-brand-membership-lilac-mid: var(--color-brand-membership-lilac-mid-5);
-  --color-brand-membership-lilac-bright: var(
-    --color-brand-membership-lilac-mid-6
-  );
-  --color-brand-membership-lilac-light: var(
-    --color-brand-membership-lilac-light-8
-  );
-  --color-brand-membership-lilac-lighter: var(
-    --color-brand-membership-lilac-light-9
-  );
-  --color-brand-membership-lilac-lightest: var(
-    --color-brand-membership-lilac-light-10
-  );
+  --color-brand-membership-lilac-bright: var(--color-brand-membership-lilac-mid-6);
+  --color-brand-membership-lilac-light: var(--color-brand-membership-lilac-light-8);
+  --color-brand-membership-lilac-lighter: var(--color-brand-membership-lilac-light-9);
+  --color-brand-membership-lilac-lightest: var(--color-brand-membership-lilac-light-10);
 
   /* Membership (Pink) */
   --color-brand-membership-pink-dark-1: #6c3e53;
@@ -64,18 +42,10 @@
   --color-brand-membership-pink-light-10: #f0e5eb;
   --color-brand-membership-pink-dark: var(--color-brand-membership-pink-dark-3);
   --color-brand-membership-pink-mid: var(--color-brand-membership-pink-mid-5);
-  --color-brand-membership-pink-bright: var(
-    --color-brand-membership-pink-mid-6
-  );
-  --color-brand-membership-pink-light: var(
-    --color-brand-membership-pink-light-8
-  );
-  --color-brand-membership-pink-lighter: var(
-    --color-brand-membership-pink-light-9
-  );
-  --color-brand-membership-pink-lightest: var(
-    --color-brand-membership-pink-light-10
-  );
+  --color-brand-membership-pink-bright: var(--color-brand-membership-pink-mid-6);
+  --color-brand-membership-pink-light: var(--color-brand-membership-pink-light-8);
+  --color-brand-membership-pink-lighter: var(--color-brand-membership-pink-light-9);
+  --color-brand-membership-pink-lightest: var(--color-brand-membership-pink-light-10);
 
   /* Membership (Orange) */
   --color-brand-membership-orange-dark-1: #783620;
@@ -86,24 +56,12 @@
   --color-brand-membership-orange-light-8: #e6bb8f;
   --color-brand-membership-orange-light-9: #f0ddd1;
   --color-brand-membership-orange-light-10: #f7eeeb;
-  --color-brand-membership-orange-dark: var(
-    --color-brand-membership-orange-dark-3
-  );
-  --color-brand-membership-orange-mid: var(
-    --color-brand-membership-orange-mid-5
-  );
-  --color-brand-membership-orange-bright: var(
-    --color-brand-membership-orange-mid-6
-  );
-  --color-brand-membership-orange-light: var(
-    --color-brand-membership-orange-light-8
-  );
-  --color-brand-membership-orange-lighter: var(
-    --color-brand-membership-orange-light-9
-  );
-  --color-brand-membership-orange-lightest: var(
-    --color-brand-membership-orange-light-10
-  );
+  --color-brand-membership-orange-dark: var(--color-brand-membership-orange-dark-3);
+  --color-brand-membership-orange-mid: var(--color-brand-membership-orange-mid-5);
+  --color-brand-membership-orange-bright: var(--color-brand-membership-orange-mid-6);
+  --color-brand-membership-orange-light: var(--color-brand-membership-orange-light-8);
+  --color-brand-membership-orange-lighter: var(--color-brand-membership-orange-light-9);
+  --color-brand-membership-orange-lightest: var(--color-brand-membership-orange-light-10);
 
   /* Membership (Yellow) */
   --color-brand-membership-yellow-dark-1: #704e24;
@@ -114,24 +72,12 @@
   --color-brand-membership-yellow-light-8: #edd273;
   --color-brand-membership-yellow-light-9: #f3e2a4;
   --color-brand-membership-yellow-light-10: #f9f1d1;
-  --color-brand-membership-yellow-dark: var(
-    --color-brand-membership-yellow-dark-3
-  );
-  --color-brand-membership-yellow-mid: var(
-    --color-brand-membership-yellow-mid-5
-  );
-  --color-brand-membership-yellow-bright: var(
-    --color-brand-membership-yellow-mid-6
-  );
-  --color-brand-membership-yellow-light: var(
-    --color-brand-membership-yellow-light-8
-  );
-  --color-brand-membership-yellow-lighter: var(
-    --color-brand-membership-yellow-light-9
-  );
-  --color-brand-membership-yellow-lightest: var(
-    --color-brand-membership-yellow-light-10
-  );
+  --color-brand-membership-yellow-dark: var(--color-brand-membership-yellow-dark-3);
+  --color-brand-membership-yellow-mid: var(--color-brand-membership-yellow-mid-5);
+  --color-brand-membership-yellow-bright: var(--color-brand-membership-yellow-mid-6);
+  --color-brand-membership-yellow-light: var(--color-brand-membership-yellow-light-8);
+  --color-brand-membership-yellow-lighter: var(--color-brand-membership-yellow-light-9);
+  --color-brand-membership-yellow-lightest: var(--color-brand-membership-yellow-light-10);
 
   /* Membership (Green) */
   --color-brand-membership-green-dark-1: #3b3f25;
@@ -142,22 +88,12 @@
   --color-brand-membership-green-light-8: #d1d4a5;
   --color-brand-membership-green-light-9: #e4e5c6;
   --color-brand-membership-green-light-10: #f6f6eb;
-  --color-brand-membership-green-dark: var(
-    --color-brand-membership-green-dark-3
-  );
+  --color-brand-membership-green-dark: var(--color-brand-membership-green-dark-3);
   --color-brand-membership-green-mid: var(--color-brand-membership-green-mid-5);
-  --color-brand-membership-green-bright: var(
-    --color-brand-membership-green-mid-6
-  );
-  --color-brand-membership-green-light: var(
-    --color-brand-membership-green-light-8
-  );
-  --color-brand-membership-green-lighter: var(
-    --color-brand-membership-green-light-9
-  );
-  --color-brand-membership-green-lightest: var(
-    --color-brand-membership-green-light-10
-  );
+  --color-brand-membership-green-bright: var(--color-brand-membership-green-mid-6);
+  --color-brand-membership-green-light: var(--color-brand-membership-green-light-8);
+  --color-brand-membership-green-lighter: var(--color-brand-membership-green-light-9);
+  --color-brand-membership-green-lightest: var(--color-brand-membership-green-light-10);
 
   /* Membership (Turquoise) */
   --color-brand-membership-turquoise-dark-1: #2b4946;
@@ -168,24 +104,12 @@
   --color-brand-membership-turquoise-light-8: #b9dad9;
   --color-brand-membership-turquoise-light-9: #d3e7e5;
   --color-brand-membership-turquoise-light-10: #ecf5f7;
-  --color-brand-membership-turquoise-dark: var(
-    --color-brand-membership-turquoise-dark-3
-  );
-  --color-brand-membership-turquoise-mid: var(
-    --color-brand-membership-turquoise-mid-5
-  );
-  --color-brand-membership-turquoise-bright: var(
-    --color-brand-membership-turquoise-mid-6
-  );
-  --color-brand-membership-turquoise-light: var(
-    --color-brand-membership-turquoise-light-8
-  );
-  --color-brand-membership-turquoise-lighter: var(
-    --color-brand-membership-turquoise-light-9
-  );
-  --color-brand-membership-turquoise-lightest: var(
-    --color-brand-membership-turquoise-light-10
-  );
+  --color-brand-membership-turquoise-dark: var(--color-brand-membership-turquoise-dark-3);
+  --color-brand-membership-turquoise-mid: var(--color-brand-membership-turquoise-mid-5);
+  --color-brand-membership-turquoise-bright: var(--color-brand-membership-turquoise-mid-6);
+  --color-brand-membership-turquoise-light: var(--color-brand-membership-turquoise-light-8);
+  --color-brand-membership-turquoise-lighter: var(--color-brand-membership-turquoise-light-9);
+  --color-brand-membership-turquoise-lightest: var(--color-brand-membership-turquoise-light-10);
 
   /* Membership (Blue) */
   --color-brand-membership-blue-dark-1: #2c4258;
@@ -198,16 +122,8 @@
   --color-brand-membership-blue-light-10: #f0f6fd;
   --color-brand-membership-blue-dark: var(--color-brand-membership-blue-dark-3);
   --color-brand-membership-blue-mid: var(--color-brand-membership-blue-mid-5);
-  --color-brand-membership-blue-bright: var(
-    --color-brand-membership-blue-mid-6
-  );
-  --color-brand-membership-blue-light: var(
-    --color-brand-membership-blue-light-8
-  );
-  --color-brand-membership-blue-lighter: var(
-    --color-brand-membership-blue-light-9
-  );
-  --color-brand-membership-blue-lightest: var(
-    --color-brand-membership-blue-light-10
-  );
+  --color-brand-membership-blue-bright: var(--color-brand-membership-blue-mid-6);
+  --color-brand-membership-blue-light: var(--color-brand-membership-blue-light-8);
+  --color-brand-membership-blue-lighter: var(--color-brand-membership-blue-light-9);
+  --color-brand-membership-blue-lightest: var(--color-brand-membership-blue-light-10);
 }

--- a/packages/shared-component--app/src/app-download.pcss
+++ b/packages/shared-component--app/src/app-download.pcss
@@ -30,8 +30,7 @@
   }
 
   @media (--mq-xlarge) {
-    padding: var(--spacing-64) var(--spacing-16)
-      calc(var(--spacing-64) + var(--spacing-8));
+    padding: var(--spacing-64) var(--spacing-16) calc(var(--spacing-64) + var(--spacing-8));
   }
 }
 
@@ -196,9 +195,7 @@
 }
 
 /* Right-hand image only */
-.coop-c-app-download__content
-  + .coop-c-app-download__media
-  .coop-c-app-download__picture {
+.coop-c-app-download__content + .coop-c-app-download__media .coop-c-app-download__picture {
   max-width: 550px;
 }
 
@@ -271,8 +268,7 @@
 }
 
 /* Connector full-width repeater (right-hand image only, aligned to bottom) */
-.coop-c-app-download__content
-  + .coop-c-app-download__media--align-bottom:after {
+.coop-c-app-download__content + .coop-c-app-download__media--align-bottom:after {
   width: 50%;
   bottom: 285px;
 
@@ -321,13 +317,11 @@
   }
 
   @media (--mq-large) {
-    padding: var(--spacing-32) var(--spacing-24)
-      calc(var(--spacing-32) + var(--spacing-8));
+    padding: var(--spacing-32) var(--spacing-24) calc(var(--spacing-32) + var(--spacing-8));
   }
 
   @media (--mq-xlarge) {
-    padding: var(--spacing-32) var(--spacing-16)
-      calc(var(--spacing-32) + var(--spacing-8));
+    padding: var(--spacing-32) var(--spacing-16) calc(var(--spacing-32) + var(--spacing-8));
   }
 }
 

--- a/packages/shared-component--editorialCard/src/editorialCard.pcss
+++ b/packages/shared-component--editorialCard/src/editorialCard.pcss
@@ -115,18 +115,14 @@
   }
 }
 
-.coop-c-editorialcard--horizontal
-  .coop-c-editorialcard__media
-  + .coop-c-editorialcard__content {
+.coop-c-editorialcard--horizontal .coop-c-editorialcard__media + .coop-c-editorialcard__content {
   @media (--mq-large) {
     padding-left: 2rem;
     padding-right: 11.25rem;
   }
 }
 
-.coop-c-editorialcard--flip
-  .coop-c-editorialcard__media
-  + .coop-c-editorialcard__content {
+.coop-c-editorialcard--flip .coop-c-editorialcard__media + .coop-c-editorialcard__content {
   @media (--mq-large) {
     padding-left: 1.25rem;
   }

--- a/packages/shared-component--featureCard/src/featureCard.pcss
+++ b/packages/shared-component--featureCard/src/featureCard.pcss
@@ -172,8 +172,7 @@
   margin-top: -7px;
 }
 
-.coop-c-featureCard__squircle--fresh_3
-  .coop-c-featureCard__squircle__uppercase {
+.coop-c-featureCard__squircle--fresh_3 .coop-c-featureCard__squircle__uppercase {
   margin-top: 32px;
 }
 
@@ -234,13 +233,11 @@
   @media (--mq-small) {
     max-width: 55%;
     flex: 1 0 55%;
-    padding: var(--spacing-base--1-4) var(--spacing-base--1-2) 0
-      var(--spacing-base--1-4);
+    padding: var(--spacing-base--1-4) var(--spacing-base--1-2) 0 var(--spacing-base--1-4);
   }
 
   @media (--mq-large) {
-    padding: var(--spacing-base--1-2) var(--spacing-base) 0
-      var(--spacing-base--1-2);
+    padding: var(--spacing-base--1-2) var(--spacing-base) 0 var(--spacing-base--1-2);
   }
 }
 
@@ -259,9 +256,7 @@
   }
 }
 
-.coop-c-featureCard--horizontal
-  .coop-c-featureCard__media
-  .coop-c-featureCard__media-wrap--16-9 {
+.coop-c-featureCard--horizontal .coop-c-featureCard__media .coop-c-featureCard__media-wrap--16-9 {
   @media (--mq-small) {
     height: auto;
   }
@@ -283,7 +278,6 @@
   }
 
   @media (--mq-medium) {
-    padding: var(--spacing-base) calc(var(--spacing-medium) * 2) 0
-      var(--spacing-base);
+    padding: var(--spacing-base) calc(var(--spacing-medium) * 2) 0 var(--spacing-base);
   }
 }

--- a/packages/shared-component--membershipFeatured/src/membership-featured.pcss
+++ b/packages/shared-component--membershipFeatured/src/membership-featured.pcss
@@ -188,9 +188,7 @@
 }
 
 /* Avoid overlapping title */
-.coop-c-membership-featured__title
-  + *
-  .coop-c-membership-featured__connector--right {
+.coop-c-membership-featured__title + * .coop-c-membership-featured__connector--right {
   display: none;
 
   @media (--mq-medium) {

--- a/packages/shared-component--membershipHero/src/membership-hero.pcss
+++ b/packages/shared-component--membershipHero/src/membership-hero.pcss
@@ -43,16 +43,12 @@
 
   /* Connector full-width repeater (left, large) */
   --membership-hero-connector-left-large-offset-x: 0;
-  --membership-hero-connector-left-large-offset-y: calc(
-    var(--spacing-48) - 8px
-  );
+  --membership-hero-connector-left-large-offset-y: calc(var(--spacing-48) - 8px);
   --membership-hero-connector-left-large-origin-x: 0;
 
   /* Connector full-width repeater (left, xlarge) */
   --membership-hero-connector-left-xlarge-offset-x: -100px;
-  --membership-hero-connector-left-xlarge-offset-y: calc(
-    var(--spacing-64) - 8px
-  );
+  --membership-hero-connector-left-xlarge-offset-y: calc(var(--spacing-64) - 8px);
   --membership-hero-connector-left-xlarge-origin-x: 0;
 
   /* Connector full-width repeater (right) */

--- a/packages/shared-component--offers/src/offers.pcss
+++ b/packages/shared-component--offers/src/offers.pcss
@@ -75,8 +75,7 @@
 }
 
 .coop-c-offersmodule__cta__link {
-  padding: calc(var(--spacing-base--1-4) * 1.75)
-    calc(var(--spacing-base--1-2) * 1.5);
+  padding: calc(var(--spacing-base--1-4) * 1.75) calc(var(--spacing-base--1-2) * 1.5);
   color: var(--color-white);
   background: var(--color-button-primary);
   font-size: 1.125rem;

--- a/packages/shared-component--offersPromo/src/offersPromo.pcss
+++ b/packages/shared-component--offersPromo/src/offersPromo.pcss
@@ -141,8 +141,7 @@
   }
 
   @media (--mq-xlarge) {
-    padding: var(--spacing-24) var(--spacing-32)
-      calc(var(--spacing-16) + var(--spacing-4));
+    padding: var(--spacing-24) var(--spacing-32) calc(var(--spacing-16) + var(--spacing-4));
   }
 }
 

--- a/packages/shared-component--totaliser/src/totaliser.pcss
+++ b/packages/shared-component--totaliser/src/totaliser.pcss
@@ -16,8 +16,7 @@
 }
 
 /* Reduce padding on pink sections following totaliser */
-.coop-c-totaliser
-  + .coop-l-section--padding-default.coop-u-brand-membership-pink-lightest-bg {
+.coop-c-totaliser + .coop-l-section--padding-default.coop-u-brand-membership-pink-lightest-bg {
   padding-top: 0;
 
   @media (--mq-small) {

--- a/workbench/.eslintrc.js
+++ b/workbench/.eslintrc.js
@@ -20,23 +20,7 @@ module.exports = {
   plugins: ['jest'],
   rules: {
     'arrow-body-style': 'off',
-    'max-len': [
-      'warn',
-      {
-        ignoreUrls: true,
-        ignoreStrings: true,
-        ignoreComments: true,
-        code: 100,
-      },
-    ],
-    'jsx-a11y/anchor-is-valid': [0, 'never'],
-    'object-curly-newline': [0, 'never'],
-    'no-plusplus': [
-      1,
-      {
-        allowForLoopAfterthoughts: true,
-      },
-    ],
+
     'import/extensions': [
       0,
       'never',

--- a/workbench/pages/components/editorial-card/index.js
+++ b/workbench/pages/components/editorial-card/index.js
@@ -18,17 +18,14 @@ const EditorialCardPage = () => {
         <section>
           <h1> Editorial Card</h1>
           <p className="coop-t-lead-p">
-            An editorial card lets you highlight and link to more in-depth
-            content on another page.
+            An editorial card lets you highlight and link to more in-depth content on another page.
           </p>
         </section>
 
         <section className="coop-u-padding-t-32">
           <p className="">npm install @coopdigital/editorialCard</p>
           <code>
-            {
-              '<EditorialCard title="Welcome to Co-op, buy some crisps! imgSrc="//image-url" />'
-            }
+            {'<EditorialCard title="Welcome to Co-op, buy some crisps! imgSrc="//image-url" />'}
           </code>
         </section>
 


### PR DESCRIPTION
- added `.prettierrc` with a view to eventually retiring the `.editorconfig`, or at least handing off part of that config to prettier
- combined some eslint rules from the workbench into the `config-eslint` package because they are worth having globally
- applied the new `max-len` rules to all component pcss files
- added `wip:` as an allowable commit type in commitlint config