### PR TITLE
fix: remove override link url from link component

### DIFF
--- a/packages/shared-component--link/src/link.html
+++ b/packages/shared-component--link/src/link.html
@@ -90,9 +90,7 @@
 
 		{# If link is external get href from content #}
 		{%- elif linkEntry.type == 'externalLink' -%}
-			{% if config.overrideLinkURL %} 
-				{%- set href = config.overrideLinkURL -%}
-			{% elif linkEntry.fields.url.data %}
+			{% if linkEntry.fields.url.data %}
 				{%- set href = linkEntry.fields.url.data -%}
 			{% endif %}
 		{%- endif -%}


### PR DESCRIPTION
Removed link url override from link component as no longer needed.