### PR TITLE
Add line height to coop headline upper

### DIFF
--- a/packages/foundations/src/typography/typography.pcss
+++ b/packages/foundations/src/typography/typography.pcss
@@ -140,6 +140,7 @@ h6,
 .coop-t-headline-upper {
   font-family: var(--font-family-headline);
   text-transform: uppercase;
+  line-height: 100%;
 }
 
 .coop-t-lead-p {


### PR DESCRIPTION
Add 100% line height to `.coop-t-headline-upper` class.
All the relevant teams are in agreement that the line height for the headline font in all caps should be 100%.
More info from [one web tech queries channel](https://co-opdigital.slack.com/archives/C0167V69R8W/p1723113880625599)

Tested locally against `http://localhost:3000/workbench/`