### PR TITLE
INS-1434: add frame title for accessibility

### DIFF
--- a/packages/shared-component--video/src/video.html
+++ b/packages/shared-component--video/src/video.html
@@ -4,6 +4,7 @@
   <iframe
     class="coop-c-video__frame"
     src="https://www.youtube.com/embed/{{ videoId }}"
+    title="YouTube video player"
     frameborder="0"
     allow="autoplay; encrypted-media"
     allowfullscreen


### PR DESCRIPTION
Adds title to video iframe to fix a lighthouse accessibility issue

<img width="741" alt="Screenshot 2024-08-12 at 16 36 59" src="https://github.com/user-attachments/assets/e322016a-57d2-4733-a8ce-da6168cb80ad">
